### PR TITLE
Fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ First, add Prophecy to the list of dependencies inside your `composer.json`:
 ```json
 {
     "require-dev": {
-        "phpspec/prophecy": "~1.0.*@dev"
+        "phpspec/prophecy": "~1.0@dev"
     }
 }
 ```


### PR DESCRIPTION
The composer version constraint should be `~1.0@dev`.  `~1.0.*@dev` returns:

```
[UnexpectedValueException]
Could not parse version constraint ~1.0.*: Invalid version string "~1.0.*"
```
