### PR TITLE
Fix namespace for MethodNotFoundException

### DIFF
--- a/src/Prophecy/Doubler/ClassPatch/ProphecySubjectPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/ProphecySubjectPatch.php
@@ -75,7 +75,7 @@ class ProphecySubjectPatch implements ClassPatchInterface
         }
 
         $__call->setCode(<<<PHP
-throw new \Prophecy\Exception\Prophecy\MethodNotFoundException(
+throw new \Prophecy\Exception\Doubler\MethodNotFoundException(
     sprintf('Method `%s::%s()` not found.', get_class(\$this), func_get_arg(0)),
     \$this->getProphecy(), func_get_arg(0)
 );


### PR DESCRIPTION
Currently, I get:

``` PHP
PHP Fatal error: Class 'Prophecy\Exception\Prophecy\MethodNotFoundException' not found in /[...]/vendor/phpspec/prophecy/src/Prophecy/Doubler/Generator/ClassCreator.php(48) : eval()'d code on line 22
```

when calling a non-existing method on a revealed object.

I believe this exception should be `\Prophecy\Exception\Doubler\MethodNotFoundException`.
