### PR TITLE
Array count token and a shortcut for it

### DIFF
--- a/spec/Prophecy/Argument/Token/ArrayCountTokenSpec.php
+++ b/spec/Prophecy/Argument/Token/ArrayCountTokenSpec.php
@@ -18,7 +18,7 @@ class ArrayCountTokenSpec extends ObjectBehavior
 
     function it_is_not_last()
     {
-        $this->isLast()->shouldBe(false);
+        $this->shouldNotBeLast();
     }
 
     function it_scores_6_if_argument_array_has_proper_count()

--- a/spec/Prophecy/ArgumentSpec.php
+++ b/spec/Prophecy/ArgumentSpec.php
@@ -51,7 +51,7 @@ class ArgumentSpec extends ObjectBehavior
 
     function it_has_a_shortcut_for_array_count_token()
     {
-        $token = $this->count(5);
+        $token = $this->size(5);
         $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\ArrayCountToken');
     }
 }

--- a/src/Prophecy/Argument.php
+++ b/src/Prophecy/Argument.php
@@ -106,7 +106,7 @@ class Argument
      * @param integer $value array elements count
      * @return Token\ArrayCountToken
      */
-    public static function count($value)
+    public static function size($value)
     {
         return new Token\ArrayCountToken($value);
     }

--- a/src/Prophecy/Argument/Token/ArrayCountToken.php
+++ b/src/Prophecy/Argument/Token/ArrayCountToken.php
@@ -38,7 +38,7 @@ class ArrayCountToken implements TokenInterface
      */
     public function scoreArgument($argument)
     {
-        return (is_array($argument) || $argument instanceof \Countable ) && $this->count === count($argument)? 6 : false;
+        return $this->isCountable($argument) && $this->hasProperCount($argument) ? 6 : false;
     }
 
     /**
@@ -59,5 +59,27 @@ class ArrayCountToken implements TokenInterface
     public function __toString()
     {
         return sprintf('count(%s)', $this->count);
+    }
+
+    /**
+     * Returns true if object is either array or instance of \Countable
+     *
+     * @param $argument
+     * @return bool
+     */
+    private function isCountable($argument)
+    {
+        return (is_array($argument) || $argument instanceof \Countable);
+    }
+
+    /**
+     * Returns true if $argument has expected number of elements
+     *
+     * @param $argument
+     * @return bool
+     */
+    private function hasProperCount($argument)
+    {
+        return $this->count === count($argument);
     }
 }


### PR DESCRIPTION
Token to assert number of elements in array or countable object.
Shortcut is `Argument::count()`
Scores 6 if argument has proper count. 
