### PR TITLE
Logical NOT token and a shortcut for it

### DIFF
--- a/spec/Prophecy/Argument/Token/LogicalNotTokenSpec.php
+++ b/spec/Prophecy/Argument/Token/LogicalNotTokenSpec.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace spec\Prophecy\Argument\Token;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument\Token\TokenInterface;
+
+class LogicalNotTokenSpec extends ObjectBehavior
+{
+    /**
+     * @param \Prophecy\Argument\Token\TokenInterface $token
+     */
+    function let($token)
+    {
+        $this->beConstructedWith($token);
+    }
+
+    function it_implements_TokenInterface()
+    {
+        $this->shouldBeAnInstanceOf('Prophecy\Argument\Token\TokenInterface');
+    }
+
+    function it_holds_originating_token($token)
+    {
+        $this->getOriginatingToken()->shouldReturn($token);
+    }
+
+    function it_has_simple_string_representation($token)
+    {
+        $token->__toString()->willReturn('value');
+        $this->__toString()->shouldBe('not(value)');
+    }
+
+    function it_wraps_non_token_argument_into_ExactValueToken()
+    {
+        $this->beConstructedWith(5);
+        $token = $this->getOriginatingToken();
+        $token->shouldhaveType('Prophecy\Argument\Token\ExactValueToken');
+        $token->getValue()->shouldBe(5);
+    }
+
+    function it_scores_4_if_preset_token_does_not_match_the_argument($token)
+    {
+        $token->scoreArgument('argument')->willReturn(false);
+        $this->scoreArgument('argument')->shouldBe(4);
+    }
+
+    function it_does_not_score_if_preset_token_matches_argument($token)
+    {
+        $token->scoreArgument('argument')->willReturn(5);
+        $this->scoreArgument('argument')->shouldBe(false);
+    }
+
+    function it_is_last_if_preset_token_is_last($token)
+    {
+        $token->isLast()->willReturn(true);
+        $this->shouldBeLast();
+    }
+
+    function it_is_not_last_if_preset_token_is_not_last($token)
+    {
+        $token->isLast()->willReturn(false);
+        $this->shouldNotBeLast();
+    }
+}

--- a/spec/Prophecy/ArgumentSpec.php
+++ b/spec/Prophecy/ArgumentSpec.php
@@ -54,4 +54,10 @@ class ArgumentSpec extends ObjectBehavior
         $token = $this->size(5);
         $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\ArrayCountToken');
     }
+
+    function it_has_a_shortcut_for_logical_not_token()
+    {
+        $token = $this->not('kagux');
+        $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\LogicalNotToken');
+    }
 }

--- a/src/Prophecy/Argument.php
+++ b/src/Prophecy/Argument.php
@@ -110,4 +110,15 @@ class Argument
     {
         return new Token\ArrayCountToken($value);
     }
+
+    /**
+     * Checks that argument does not match the value|token.
+     *
+     * @param mixed $value either exact value or argument token
+     * @return Token\LogicalNotToken
+     */
+    public static function not($value)
+    {
+        return new Token\LogicalNotToken($value);
+    }
 }

--- a/src/Prophecy/Argument/Token/LogicalNotToken.php
+++ b/src/Prophecy/Argument/Token/LogicalNotToken.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Prophecy\Argument\Token;
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Logical NOT token.
+ *
+ * @author Boris Mikhaylov <kaguxmail@gmail.com>
+ */
+class LogicalNotToken implements TokenInterface
+{
+    /** @var \Prophecy\Argument\Token\TokenInterface  */
+    private $token;
+
+    /**
+     * @param mixed $value exact value or token
+     */
+    public function __construct($value)
+    {
+        $this->token = $value instanceof TokenInterface? $value : new ExactValueToken($value);
+    }
+
+    /**
+     * Scores 4 when preset token does not match the argument.
+     *
+     * @param $argument
+     *
+     * @return bool|int
+     */
+    public function scoreArgument($argument)
+    {
+        return false === $this->token->scoreArgument($argument) ? 4 : false;
+    }
+
+    /**
+     * Returns true if preset token is last.
+     *
+     * @return bool|int
+     */
+    public function isLast()
+    {
+        return $this->token->isLast();
+    }
+
+    /**
+     * Returns originating token.
+     *
+     * @return TokenInterface
+     */
+    public function getOriginatingToken()
+    {
+        return $this->token;
+    }
+
+    /**
+     * Returns string representation for token.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return sprintf('not(%s)', $this->token);
+    }
+}


### PR DESCRIPTION
Token `Argument::not` to negate scoring of another token.
It scores 8 when preset token does not score the argument.
