### PR TITLE
Array entry token and shortcuts to match entry, key or value

### DIFF
--- a/spec/Prophecy/Argument/Token/ArrayEntryTokenSpec.php
+++ b/spec/Prophecy/Argument/Token/ArrayEntryTokenSpec.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace spec\Prophecy\Argument\Token;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Prophecy\Exception\InvalidArgumentException;
+
+class ArrayEntryTokenSpec extends ObjectBehavior
+{
+    /**
+     * @param \Prophecy\Argument\Token\TokenInterface $key
+     * @param \Prophecy\Argument\Token\TokenInterface $value
+     */
+    function let($key, $value)
+    {
+        $this->beConstructedWith($key, $value);
+    }
+
+    function it_implements_TokenInterface()
+    {
+        $this->shouldBeAnInstanceOf('Prophecy\Argument\Token\TokenInterface');
+    }
+
+    function it_is_not_last()
+    {
+        $this->shouldNotBeLast();
+    }
+
+    function it_holds_key_and_value($key, $value)
+    {
+        $this->getKey()->shouldBe($key);
+        $this->getValue()->shouldBe($value);
+    }
+
+    function its_string_representation_tells_that_its_an_array_containing_the_key_value_pair($key, $value)
+    {
+        $key->__toString()->willReturn('key');
+        $value->__toString()->willReturn('value');
+        $this->__toString()->shouldBe('[..., key => value, ...]');
+    }
+
+    /**
+     * @param \Prophecy\Argument\Token\TokenInterface $key
+     * @param \stdClass $object
+     */
+    function it_wraps_non_token_value_into_ExactValueToken($key, $object)
+    {
+        $this->beConstructedWith($key, $object);
+        $this->getValue()->shouldHaveType('\Prophecy\Argument\Token\ExactValueToken');
+    }
+
+    /**
+     * @param \stdClass $object
+     * @param \Prophecy\Argument\Token\TokenInterface $value
+     */
+    function it_wraps_non_token_key_into_ExactValueToken($object, $value)
+    {
+        $this->beConstructedWith($object, $value);
+        $this->getKey()->shouldHaveType('\Prophecy\Argument\Token\ExactValueToken');
+    }
+
+    function it_scores_array_half_of_combined_scores_from_key_and_value_tokens($key, $value)
+    {
+        $key->scoreArgument('key')->willReturn(4);
+        $value->scoreArgument('value')->willReturn(6);
+        $this->scoreArgument(array('key'=>'value'))->shouldBe(5);
+    }
+
+    /**
+     * @param \Prophecy\Argument\Token\TokenInterface $key
+     * @param \Prophecy\Argument\Token\TokenInterface $value
+     * @param \Iterator $object
+     */
+    function it_scores_traversable_object_half_of_combined_scores_from_key_and_value_tokens($key, $value, $object)
+    {
+        $object->current()->will(function() use($object){
+            $object->valid()->willReturn(false);
+            return 'value';
+        });
+        $object->key()->willReturn('key');
+        $object->rewind()->willReturn(null);
+        $object->next()->willReturn(null);
+        $object->valid()->willReturn(true);
+        $key->scoreArgument('key')->willReturn(6);
+        $value->scoreArgument('value')->willReturn(2);
+        $this->scoreArgument($object)->shouldBe(4);
+    }
+
+    /**
+     * @param \Prophecy\Argument\Token\AnyValuesToken $key
+     * @param \Prophecy\Argument\Token\TokenInterface $value
+     * @param \ArrayAccess $object
+     */
+    function it_throws_exception_during_scoring_of_array_accessible_object_if_key_is_not_ExactValueToken($key, $value, $object)
+    {
+        $this->beConstructedWith($key,$value);
+        $class = get_class($key->getWrappedObject());
+        $errorMessage = 'You can only use ExactValueToken to match keys of object '.
+                        'that implements ArrayAccess interface. '.
+                        'You used a token of type "'.$class.'"';
+        $this->shouldThrow(new InvalidArgumentException($errorMessage))->duringScoreArgument($object);
+    }
+
+    /**
+     * @param \Prophecy\Argument\Token\ExactValueToken $key
+     * @param \Prophecy\Argument\Token\TokenInterface $value
+     * @param \ArrayAccess $object
+     */
+    function it_scores_array_accessible_object_half_of_combined_scores_from_key_and_value_tokens($key, $value, $object)
+    {
+        $object->offsetExists('key')->willReturn(true);
+        $object->offsetGet('key')->willReturn('value');
+        $key->getValue()->willReturn('key');
+        $key->scoreArgument('key')->willReturn(3);
+        $value->scoreArgument('value')->willReturn(1);
+        $this->scoreArgument($object)->shouldBe(2);
+    }
+
+    /**
+     * @param \Prophecy\Argument\Token\AnyValuesToken $key
+     * @param \Prophecy\Argument\Token\TokenInterface $value
+     * @param \ArrayIterator $object
+     */
+    function it_accepts_any_key_token_type_to_score_object_that_is_both_traversable_and_array_accessible($key, $value, $object)
+    {
+        $this->beConstructedWith($key, $value);
+        $object->current()->will(function() use($object){
+            $object->valid()->willReturn(false);
+            return 'value';
+        });
+        $object->key()->willReturn('key');
+        $object->rewind()->willReturn(null);
+        $object->next()->willReturn(null);
+        $object->valid()->willReturn(true);
+        $this->shouldNotThrow(new InvalidArgumentException)->duringScoreArgument($object);
+    }
+
+    function it_does_not_score_if_argument_is_neither_array_nor_traversable_nor_array_accessible()
+    {
+        $this->scoreArgument('string')->shouldBe(false);
+        $this->scoreArgument(new \stdClass)->shouldBe(false);
+    }
+
+    function it_does_not_score_empty_array()
+    {
+        $this->scoreArgument(array())->shouldBe(false);
+    }
+
+    function it_does_not_score_array_if_key_and_value_tokens_do_not_score_same_entry($key, $value)
+    {
+        $argument = array(1 => 'foo', 2 => 'bar');
+        $key->scoreArgument(1)->willReturn(true);
+        $key->scoreArgument(2)->willReturn(false);
+        $value->scoreArgument('foo')->willReturn(false);
+        $value->scoreArgument('bar')->willReturn(true);
+        $this->scoreArgument($argument)->shouldBe(false);
+    }
+
+    /**
+     * @param \Iterator $object
+     */
+    function it_does_not_score_traversable_object_without_entries($object)
+    {
+        $object->rewind()->willReturn(null);
+        $object->next()->willReturn(null);
+        $object->valid()->willReturn(false);
+        $this->scoreArgument($object)->shouldBe(false);
+    }
+
+    /**
+     * @param \Prophecy\Argument\Token\TokenInterface $key
+     * @param \Prophecy\Argument\Token\TokenInterface $value
+     * @param \Iterator $object
+     */
+    function it_does_not_score_traversable_object_if_key_and_value_tokens_do_not_score_same_entry($key, $value, $object)
+    {
+        $object->current()->willReturn('foo');
+        $object->current()->will(function() use($object){
+            $object->valid()->willReturn(false);
+            return 'bar';
+        });
+        $object->key()->willReturn(1);
+        $object->key()->willReturn(2);
+        $object->rewind()->willReturn(null);
+        $object->next()->willReturn(null);
+        $object->valid()->willReturn(true);
+        $key->scoreArgument(1)->willReturn(true);
+        $key->scoreArgument(2)->willReturn(false);
+        $value->scoreArgument('foo')->willReturn(false);
+        $value->scoreArgument('bar')->willReturn(true);
+        $this->scoreArgument($object)->shouldBe(false);
+    }
+
+    /**
+     * @param \Prophecy\Argument\Token\ExactValueToken $key
+     * @param \ArrayAccess $object
+     */
+    function it_does_not_score_array_accessible_object_if_it_has_no_offset_with_key_token_value($key, $object)
+    {
+        $object->offsetExists('key')->willReturn(false);
+        $key->getValue()->willReturn('key');
+        $this->scoreArgument($object)->shouldBe(false);
+    }
+
+    /**
+     * @param \Prophecy\Argument\Token\ExactValueToken $key
+     * @param \Prophecy\Argument\Token\TokenInterface $value
+     * @param \ArrayAccess $object
+     */
+    function it_does_not_score_array_accessible_object_if_key_and_value_tokens_do_not_score_same_entry($key, $value, $object)
+    {
+        $object->offsetExists('key')->willReturn(true);
+        $object->offsetGet('key')->willReturn('value');
+        $key->getValue()->willReturn('key');
+        $value->scoreArgument('value')->willReturn(false);
+        $key->scoreArgument('key')->willReturn(true);
+        $this->scoreArgument($object)->shouldBe(false);
+    }
+
+    function its_score_is_capped_at_8($key, $value)
+    {
+        $key->scoreArgument('key')->willReturn(10);
+        $value->scoreArgument('value')->willReturn(10);
+        $this->scoreArgument(array('key'=>'value'))->shouldBe(8);
+    }
+}

--- a/spec/Prophecy/ArgumentSpec.php
+++ b/spec/Prophecy/ArgumentSpec.php
@@ -55,6 +55,26 @@ class ArgumentSpec extends ObjectBehavior
         $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\ArrayCountToken');
     }
 
+    function it_has_a_shortcut_for_array_entry_token()
+    {
+        $token = $this->withEntry('key', 'value');
+        $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\ArrayEntryToken');
+    }
+
+    function it_has_a_shortcut_for_array_entry_token_matching_any_key()
+    {
+        $token = $this->containing('value');
+        $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\ArrayEntryToken');
+        $token->getKey()->shouldHaveType('Prophecy\Argument\Token\AnyValueToken');
+    }
+
+    function it_has_a_shortcut_for_array_entry_token_matching_any_value()
+    {
+        $token = $this->withKey('key');
+        $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\ArrayEntryToken');
+        $token->getValue()->shouldHaveType('Prophecy\Argument\Token\AnyValueToken');
+    }
+
     function it_has_a_shortcut_for_logical_not_token()
     {
         $token = $this->not('kagux');

--- a/src/Prophecy/Argument.php
+++ b/src/Prophecy/Argument.php
@@ -112,6 +112,40 @@ class Argument
     }
 
     /**
+     * Checks that argument array contains (key, value) pair
+     *
+     * @param mixed $key exact value or token
+     * @param mixed $value exact value or token
+     * @return Token\ArrayEntryToken
+     */
+    public static function withEntry($key, $value)
+    {
+        return new Token\ArrayEntryToken($key, $value);
+    }
+
+    /**
+     * Checks that argument array contains value
+     *
+     * @param mixed $value
+     * @return Token\ArrayEntryToken
+     */
+    public static function containing($value)
+    {
+        return new Token\ArrayEntryToken(self::any(), $value);
+    }
+
+    /**
+     * Checks that argument array has key
+     *
+     * @param mixed $key exact value or token
+     * @return Token\ArrayEntryToken
+     */
+    public static function withKey($key)
+    {
+        return new Token\ArrayEntryToken($key, self::any());
+    }
+
+    /**
      * Checks that argument does not match the value|token.
      *
      * @param mixed $value either exact value or argument token

--- a/src/Prophecy/Argument/Token/ArrayEntryToken.php
+++ b/src/Prophecy/Argument/Token/ArrayEntryToken.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Prophecy\Argument\Token;
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use Prophecy\Exception\InvalidArgumentException;
+
+/**
+ * Array entry token.
+ *
+ * @author Boris Mikhaylov <kaguxmail@gmail.com>
+ */
+class ArrayEntryToken implements TokenInterface
+{
+    /** @var \Prophecy\Argument\Token\TokenInterface */
+    private $key;
+    /** @var \Prophecy\Argument\Token\TokenInterface */
+    private $value;
+
+    /**
+     * @param mixed $key exact value or token
+     * @param mixed $value exact value or token
+     */
+    public function __construct($key, $value)
+    {
+        $this->key = $this->wrapIntoExactValueToken($key);
+        $this->value = $this->wrapIntoExactValueToken($value);
+    }
+
+    /**
+     * Scores half of combined scores from key and value tokens for same entry. Capped at 8.
+     * If argument implements \ArrayAccess without \Traversable, then key token is restricted to ExactValueToken.
+     *
+     * @param array|\ArrayAccess|\Traversable $argument
+     *
+     * @throws \Prophecy\Exception\InvalidArgumentException
+     * @return bool|int
+     */
+    public function scoreArgument($argument)
+    {
+        if($argument instanceof \Traversable){
+            $argument = iterator_to_array($argument);
+        }
+
+        if($argument instanceof \ArrayAccess){
+            $argument = $this->convertArrayAccessToEntry($argument);
+        }
+
+        if(!is_array($argument) || empty($argument)){
+            return false;
+        }
+
+        $keyScores = array_map(array($this->key,'scoreArgument'), array_keys($argument));
+        $valueScores = array_map(array($this->value,'scoreArgument'), $argument);
+        $scoreEntry = function ($value, $key) {
+            return $value && $key ? min(8, ($key + $value) / 2) : false;
+        };
+
+        return max(array_map($scoreEntry, $valueScores, $keyScores));
+    }
+
+    /**
+     * Returns false.
+     *
+     * @return bool|int
+     */
+    public function isLast()
+    {
+        return false;
+    }
+
+    /**
+     * Returns string representation for token.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return sprintf('[..., %s => %s, ...]', $this->key, $this->value);
+    }
+
+    /**
+     * Returns key
+     *
+     * @return TokenInterface
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * Returns value
+     *
+     * @return TokenInterface
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Wraps non token $value into ExactValueToken
+     *
+     * @param $value
+     * @return TokenInterface
+     */
+    private function wrapIntoExactValueToken($value)
+    {
+        return $value instanceof TokenInterface ? $value : new ExactValueToken($value);
+    }
+
+    /**
+     * Converts instance of \ArrayAccess to key => value array entry
+     * @param \ArrayAccess $object
+     * @return array|null
+     * @throws \Prophecy\Exception\InvalidArgumentException
+     */
+    private function convertArrayAccessToEntry(\ArrayAccess $object)
+    {
+        if(!$this->key instanceof ExactValueToken){
+            throw new InvalidArgumentException(sprintf('You can only use ExactValueToken to match keys of object '.
+            'that implements ArrayAccess interface. '.
+            'You used a token of type "%s"', get_class($this->key)));
+        }
+
+        $key = $this->key->getValue();
+
+        return $object->offsetExists($key) ? array($key => $object[$key]) : array();
+    }
+}


### PR DESCRIPTION
Token comes with 3 shortcuts:
- `Argument::withEntry($key, $value)` to check if array contains (key, value) pair. 
- `Argument::withKey($key)` to check if array contains key
- `Argument::containing($value)` to check if array contains value

Both `$key` and `$value` can be either exact values or tokens. 
It only scores when both `$key` and `$value` score at least one same entry in the array. 
The most debatable part is how to score matched entries. I ended up choosing to calculate it as `(key_score + value_score) / 2` and cap it at 8.  It takes both tokens into account and should keep fair priorities.
