### PR TITLE
Added prophesying static methods and introduced PropertyNode

### DIFF
--- a/spec/Prophecy/Doubler/Generator/Node/ClassNodeSpec.php
+++ b/spec/Prophecy/Doubler/Generator/Node/ClassNodeSpec.php
@@ -121,24 +121,47 @@ class ClassNodeSpec extends ObjectBehavior
         $this->getProperties()->shouldHaveCount(0);
     }
 
-    function it_is_able_to_have_properties()
+    /**
+     * @param Prophecy\Doubler\Generator\Node\PropertyNode $property1
+     * @param Prophecy\Doubler\Generator\Node\PropertyNode $property2
+     */
+    function it_is_able_to_have_properties($property1, $property2)
     {
-        $this->addProperty('title');
-        $this->addProperty('text', 'private');
+        $property1->getName()->willReturn('title');
+        $property2->getName()->willReturn('text');
+
+        $this->addProperty($property1);
+        $this->addProperty($property2);
+
         $this->getProperties()->shouldReturn(array(
-            'title' => 'public',
-            'text'  => 'private'
+            'title' => $property1,
+            'text'  => $property2
         ));
     }
 
-    function its_addProperty_does_not_accept_unsupported_visibility()
+    /**
+     * @param Prophecy\Doubler\Generator\Node\MethodNode $method
+     */
+    function its_hasStaticMethods_returns_true_if_a_static_method_exists($method)
     {
-        $this->shouldThrow('InvalidArgumentException')->duringAddProperty('title', 'town');
+        $method->getName()->willReturn('getName');
+        $method->isStatic()->willReturn(true);
+
+        $this->addMethod($method);
+
+        $this->hasStaticMethods()->shouldReturn(true);
     }
 
-    function its_addProperty_lowercases_visibility_before_setting()
+    /**
+     * @param Prophecy\Doubler\Generator\Node\MethodNode $method
+     */
+    function its_hasStaticMethods_returns_false_if_a_static_method_does_not_exist($method)
     {
-        $this->addProperty('text', 'PRIVATE');
-        $this->getProperties()->shouldReturn(array('text' => 'private'));
+        $method->getName()->willReturn('getName');
+        $method->isStatic()->willReturn(false);
+
+        $this->addMethod($method);
+
+        $this->hasStaticMethods()->shouldReturn(false);
     }
 }

--- a/spec/Prophecy/Doubler/Generator/Node/PropertyNodeSpec.php
+++ b/spec/Prophecy/Doubler/Generator/Node/PropertyNodeSpec.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace spec\Prophecy\Doubler\Generator\Node;
+
+use PhpSpec\ObjectBehavior;
+
+class PropertyNodeSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('title');
+    }
+
+    function it_has_a_name()
+    {
+        $this->getName()->shouldReturn('title');
+    }
+
+    function it_has_public_visibility_by_default()
+    {
+        $this->getVisibility()->shouldReturn('public');
+    }
+
+    function its_visibility_is_mutable()
+    {
+        $this->setVisibility('private');
+        $this->getVisibility()->shouldReturn('private');
+    }
+
+    function it_is_not_static_by_default()
+    {
+        $this->shouldNotBeStatic();
+    }
+
+    function it_should_be_settable_as_static_through_setter()
+    {
+        $this->setStatic();
+        $this->shouldBeStatic();
+    }
+
+    function it_accepts_only_supported_visibilities()
+    {
+        $this->shouldThrow('InvalidArgumentException')->duringSetVisibility('stealth');
+    }
+
+    function it_lowercases_visibility_before_setting_it()
+    {
+        $this->setVisibility('Public');
+        $this->getVisibility()->shouldReturn('public');
+    }
+}

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -39,8 +39,9 @@ class ClassCodeGenerator
             )
         );
 
-        foreach ($class->getProperties() as $name => $visibility) {
-            $code .= sprintf("%s \$%s;\n", $visibility, $name);
+        foreach ($class->getProperties() as $property) {
+            $code .= sprintf("%s %s\$%s;\n", $property->getVisibility(),
+                $property->isStatic() ? 'static ' : '', $property->getName());
         }
         $code .= "\n";
 

--- a/src/Prophecy/Doubler/Generator/Node/ClassNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/ClassNode.php
@@ -59,17 +59,9 @@ class ClassNode
         return $this->properties;
     }
 
-    public function addProperty($name, $visibility = 'public')
+    public function addProperty(PropertyNode $property)
     {
-        $visibility = strtolower($visibility);
-
-        if (!in_array($visibility, array('public', 'private', 'protected'))) {
-            throw new InvalidArgumentException(sprintf(
-                '`%s` property visibility is not supported.', $visibility
-            ));
-        }
-
-        $this->properties[$name] = $visibility;
+        $this->properties[$property->getName()] = $property;
     }
 
     public function getMethods()
@@ -90,5 +82,16 @@ class ClassNode
     public function hasMethod($name)
     {
         return isset($this->methods[$name]);
+    }
+
+    public function hasStaticMethods()
+    {
+        foreach ($this->methods as $method) {
+            if ($method->isStatic()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Prophecy/Doubler/Generator/Node/PropertyNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/PropertyNode.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Prophecy\Doubler\Generator\Node;
+
+use Prophecy\Exception\InvalidArgumentException;
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Property node.
+ */
+class PropertyNode
+{
+    private $name;
+    private $visibility = 'public';
+    private $static = false;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getVisibility()
+    {
+        return $this->visibility;
+    }
+
+    public function setVisibility($visibility)
+    {
+        $visibility = strtolower($visibility);
+
+        if (!in_array($visibility, array('public', 'private', 'protected'))) {
+            throw new InvalidArgumentException(sprintf(
+                '`%s` property visibility is not supported.', $visibility
+            ));
+        }
+
+        $this->visibility = $visibility;
+    }
+
+    public function isStatic()
+    {
+        return $this->static;
+    }
+
+    public function setStatic($static = true)
+    {
+        $this->static = (bool) $static;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/src/Prophecy/Prophecy/ObjectProphecy.php
+++ b/src/Prophecy/Prophecy/ObjectProphecy.php
@@ -86,9 +86,10 @@ class ObjectProphecy implements ProphecyInterface
     {
         $double = $this->lazyDouble->getInstance();
 
-        if (null === $double || !$double instanceof ProphecySubjectInterface) {
+        if (null === $double || (!$double instanceof ProphecySubjectInterface &&
+            !$double instanceof StaticProphecySubjectInterface)) {
             throw new ObjectProphecyException(
-                "Generated double must implement ProphecySubjectInterface, but it does not.\n".
+                "Generated double must implement ProphecySubjectInterface or StaticProphecySubjectInterface, but it does not.\n".
                 'It seems you have wrongly configured doubler without required ClassPatch.',
                 $this
             );

--- a/src/Prophecy/Prophecy/StaticProphecySubjectInterface.php
+++ b/src/Prophecy/Prophecy/StaticProphecySubjectInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Prophecy\Prophecy;
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Controllable static doubles interface.
+ */
+interface StaticProphecySubjectInterface
+{
+    /**
+     * Sets subject prophecy.
+     *
+     * @param ProphecyInterface $prophecy
+     */
+    public static function setProphecy(ProphecyInterface $prophecy);
+
+    /**
+     * Returns subject prophecy.
+     *
+     * @return ProphecyInterface
+     */
+    public static function getProphecy();
+}


### PR DESCRIPTION
I really hate static methods ... I do :) 

But sometimes we have to work with 3rd party and this was the case in here.
## Example

I had a third party class which looked more or less like this:

``` php
class SomeClass
{
  public static function getSomething()
  {
    return 'something';
  }
}
```
## The Problem

So as a hater of static methods I wanted to keep my code clean and do something like

``` php
$anything = new SomeClass();
$something = $anything->getSomething();
```

Or even better get an instance of `SomeClass` as a `Symfony2` service.

But when I was doing specs with mocking of `SomeClass` in `PhpSpec` I did get a fatal error about using `$this in non-object context` when implementing.

As it turned out the prophesized method looked something like this:

``` php
//...
public static function getSomething()
{
  return $this->getProphecy()->makeProphecyMethodCall(__FUNCTION__, func_get_args());
}
```

So in the PR is my proposition on how to handle this particular scenario by adding static calls to object prophecy in generated class.
