### PR TITLE
fixed Argument/Token/ExactValueToken not checking for object

### DIFF
--- a/spec/Prophecy/Argument/Token/ExactValueTokenSpec.php
+++ b/spec/Prophecy/Argument/Token/ExactValueTokenSpec.php
@@ -29,11 +29,38 @@ class ExactValueTokenSpec extends ObjectBehavior
     function it_scores_10_if_value_is_equal_to_argument()
     {
         $this->scoreArgument(42)->shouldReturn(10);
+        $this->scoreArgument('42')->shouldReturn(10);
+    }
+
+    function it_scores_10_if_value_is_an_object_and_equal_to_argument()
+    {
+        $value = new \DateTime();
+        $value2 = clone $value;
+
+        $this->beConstructedWith($value);
+        $this->scoreArgument($value2)->shouldReturn(10);
     }
 
     function it_does_not_scores_if_value_is_not_equal_to_argument()
     {
         $this->scoreArgument(50)->shouldReturn(false);
+        $this->scoreArgument(new \stdClass())->shouldReturn(false);
+    }
+
+    function it_does_not_scores_if_value_an_object_and_is_not_equal_to_argument()
+    {
+        $value = new \stdClass();
+        $value2 = new \stdClass();
+        $value2->foo = 'bar';
+
+        $this->beConstructedWith($value);
+        $this->scoreArgument($value2)->shouldReturn(false);
+    }
+
+    function it_does_not_scores_if_value_type_and_is_not_equal_to_argument()
+    {
+        $this->beConstructedWith(false);
+        $this->scoreArgument(0)->shouldReturn(false);
     }
 
     function it_generates_proper_string_representation_for_integer()

--- a/src/Prophecy/Argument/Token/ExactValueToken.php
+++ b/src/Prophecy/Argument/Token/ExactValueToken.php
@@ -45,6 +45,25 @@ class ExactValueToken implements TokenInterface
      */
     public function scoreArgument($argument)
     {
+        if (is_object($argument) && is_object($this->value) && $argument == $this->value) {
+            return 10;
+        }
+
+        // If either one is an object it should castable to a string
+        if (is_object($argument) xor is_object($this->value)) {
+            if (is_object($argument) && !method_exists($argument, '__toString')) {
+                return false;
+            }
+
+            if (is_object($this->value) && !method_exists($this->value, '__toString')) {
+                return false;
+            }
+        } elseif (is_numeric($argument) && is_numeric($this->value)) {
+            // noop
+        } elseif (gettype($argument) !== gettype($this->value)) {
+            return false;
+        }
+
         return $argument == $this->value ? 10 : false;
     }
 


### PR DESCRIPTION
This increased the strictness checking of the argument-score, and ensures objects are only converted to a string when actually possible. This fixes issue #42
