### PR TITLE
Add RecordArgumentsPromise which records the last arguments executed.

### DIFF
--- a/spec/Prophecy/Promise/RecordArgumentsPromiseSpec.php
+++ b/spec/Prophecy/Promise/RecordArgumentsPromiseSpec.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace spec\Prophecy\Promise;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class RecordArgumentsPromiseSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Prophecy\Promise\RecordArgumentsPromise');
+    }
+
+    /**
+     * @param Prophecy\Prophecy\ObjectProphecy $object
+     * @param Prophecy\Prophecy\MethodProphecy $method
+     */
+    function it_should_store_arguments($object, $method)
+    {
+        $arguments = array('one', 'two');
+        $this->execute($arguments, $object, $method)->shouldReturn(null);
+
+        // Retrieved arguments should be the same as the passed arguments
+        $this->getArguments()->shouldBeEqualTo($arguments);
+    }
+}

--- a/src/Prophecy/Promise/RecordArgumentsPromise.php
+++ b/src/Prophecy/Promise/RecordArgumentsPromise.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Prophecy\Promise;
+
+use Prophecy\Promise\PromiseInterface;
+use Prophecy\Prophecy\ObjectProphecy;
+use Prophecy\Prophecy\MethodProphecy;
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Records argument promise.
+ *
+ * This promise stores the arguments passed during execution in the variable
+ * provided during construction.
+ *
+ * @author Liam O'Boyle <liam@ontheroad.net.nz>
+ */
+class RecordArgumentsPromise implements PromiseInterface
+{
+    protected $storage;
+
+    /**
+     * Retrieve the stored arguments from the promise.
+     *
+     * @return mixed
+     */
+    public function getArguments() {
+        return $this->storage;
+    }
+
+    /**
+     * Evaluates promise callback.
+     *
+     * @param array          $args
+     * @param ObjectProphecy $object
+     * @param MethodProphecy $method
+     *
+     * @return mixed
+     */
+    public function execute(array $args, ObjectProphecy $object, MethodProphecy $method)
+    {
+        $this->storage = $args;
+    }
+}


### PR DESCRIPTION
RecordArgumentsPromise can be used to record the last arguments provided to a promise.

``` php
$prophecy = $this->prophesize('My\Class');
$prophecy
    ->doSomething(Prophecy\Argument::any())
    ->will($return = new RecordArgumentsPromise);
$prophecy->reveal()->doSomething('foo', 'bar');

// Called arguments are now available
$arguments = $return->getArguments();
```
