### PR TITLE
fixed ObjectProphecy to not let PHP cast values of ArgumentsWildcard

### DIFF
--- a/src/Prophecy/Prophecy/ObjectProphecy.php
+++ b/src/Prophecy/Prophecy/ObjectProphecy.php
@@ -229,7 +229,8 @@ class ObjectProphecy implements ProphecyInterface
         $arguments = new ArgumentsWildcard($this->revealer->reveal($arguments));
 
         foreach ($this->getMethodProphecies($methodName) as $prophecy) {
-            if ($prophecy->getArgumentsWildcard() == $arguments) {
+            // Use the silence operator to suppress any notice about object to integer casting
+            if (@($prophecy->getArgumentsWildcard() == $arguments)) {
                 return $prophecy;
             }
         }


### PR DESCRIPTION
Yesterday I hit a rather nasty bug (feature), and spend almost the entire day finding out why PHP kept failing with "Notice: Object of class DateTime could not be converted to int in [...]src/Prophecy/Prophecy/ObjectProphecy.php on line 232"

In turned out when PHP compares two objects or arrays, and either one contains an integer the other value is casted to an integer. :boom:

This simple script demonstrates this "great feature".

``` php
if (array(10) == array(new \DateTime())) {
    echo 'oke';
}
```

And using array_diff() actually makes it worse as that produces a catchable fatal error...

Fortunately I found a simple fix/hack around this problem.
Instead of comparing the objects as-is, we serialize them and then compare the serialized results (strings) and that works perfect (no failing specs so far).

Only thing is that I'm not able to write a test/spec to make sure this does not happen again.
But for now it fixes this problem.
