### PR TITLE
Switched the NameGenerator to a static counter instead of a random suffix

### DIFF
--- a/src/Prophecy/Doubler/NameGenerator.php
+++ b/src/Prophecy/Doubler/NameGenerator.php
@@ -21,6 +21,8 @@ use ReflectionClass;
  */
 class NameGenerator
 {
+    private static $counter = 1;
+
     /**
      * Generates name.
      *
@@ -45,6 +47,6 @@ class NameGenerator
             $parts[] = 'stdClass';
         }
 
-        return sprintf('Double\%s\P%d', implode('\\', $parts), mt_rand());
+        return sprintf('Double\%s\P%d', implode('\\', $parts), self::$counter++);
     }
 }


### PR DESCRIPTION
This ensures that the doubler does not generate duplicate class name even when the generation runs too fast for the entropy source.
Closes #38
Replaces #64 by avoiding to slow down the library artificially because of md5.
