### PR TITLE
Made and prefix possible

### DIFF
--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -373,6 +373,20 @@ class MethodProphecy
     {
         return $this->argumentsWildcard;
     }
+    
+    public function __call($method, array $arguments)
+    {
+        if ('and' === substr($method, 0, 3)) {
+            $realMethod = lcfirst(substr($method, 3));
+            if (method_exists($this, $realMethod)) {
+                call_user_func_array(array($this, $realMethod), $arguments);
+                
+                return;
+            }
+        }
+        
+        throw new \BadMethodCallException('Called undefined method '.$method);
+    }
 
     private function bindToObjectProphecy()
     {


### PR DESCRIPTION
This will allow to do:

``` php
$obj->method()->shouldBeCalled()->andWillReturn(...);
```

Which is a lot nicer to read/write then:

``` php
$obj->method()->shouldBeCalled()->willReturn(...);
```
