### PR TITLE
Spy automatically promotes spied method call to an expected one

### DIFF
--- a/spec/Prophecy/Prophecy/MethodProphecySpec.php
+++ b/spec/Prophecy/Prophecy/MethodProphecySpec.php
@@ -177,11 +177,54 @@ class MethodProphecySpec extends ObjectBehavior
         $objectProphecy, $arguments, $prediction, $call1, $call2
     )
     {
+        $objectProphecy->addMethodProphecy($this)->willReturn(null);
         $prediction->check(array($call1, $call2), $objectProphecy->getWrappedObject(), $this)->shouldBeCalled();
         $objectProphecy->findProphecyMethodCalls('getName', $arguments)->willReturn(array($call1, $call2));
 
         $this->withArguments($arguments);
         $this->callOnWrappedObject('shouldHave', array($prediction));
+    }
+
+    /**
+     * @param \Prophecy\Argument\ArgumentsWildcard     $arguments
+     * @param \Prophecy\Prediction\PredictionInterface $prediction
+     * @param \Prophecy\Call\Call                      $call1
+     * @param \Prophecy\Call\Call                      $call2
+     */
+    function it_sets_return_promise_during_shouldHave_call_if_none_was_set_before(
+        $objectProphecy, $arguments, $prediction, $call1, $call2
+    )
+    {
+        $objectProphecy->addMethodProphecy($this)->willReturn(null);
+        $prediction->check(array($call1, $call2), $objectProphecy->getWrappedObject(), $this)->shouldBeCalled();
+        $objectProphecy->findProphecyMethodCalls('getName', $arguments)->willReturn(array($call1, $call2));
+
+        $this->withArguments($arguments);
+        $this->callOnWrappedObject('shouldHave', array($prediction));
+
+        $this->getPromise()->shouldReturnAnInstanceOf('Prophecy\Promise\ReturnPromise');
+    }
+
+    /**
+     * @param \Prophecy\Argument\ArgumentsWildcard     $arguments
+     * @param \Prophecy\Prediction\PredictionInterface $prediction
+     * @param \Prophecy\Call\Call                      $call1
+     * @param \Prophecy\Call\Call                      $call2
+     * @param \Prophecy\Promise\PromiseInterface       $promise
+     */
+    function it_does_not_set_return_promise_during_shouldHave_call_if_it_was_set_before(
+        $objectProphecy, $arguments, $prediction, $call1, $call2, $promise
+    )
+    {
+        $objectProphecy->addMethodProphecy($this)->willReturn(null);
+        $prediction->check(array($call1, $call2), $objectProphecy->getWrappedObject(), $this)->shouldBeCalled();
+        $objectProphecy->findProphecyMethodCalls('getName', $arguments)->willReturn(array($call1, $call2));
+
+        $this->will($promise);
+        $this->withArguments($arguments);
+        $this->callOnWrappedObject('shouldHave', array($prediction));
+
+        $this->getPromise()->shouldReturn($promise);
     }
 
     /**

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -250,6 +250,10 @@ class MethodProphecy
             ));
         }
 
+        if (null === $this->promise) {
+            $this->willReturn();
+        }
+
         $calls = $this->getObjectProphecy()->findProphecyMethodCalls(
             $this->getMethodName(),
             $this->getArgumentsWildcard()


### PR DESCRIPTION
Before this commit, spies were unusable if you had defined any promise or prediction on the object
you were spying to. Because call still wasn't been marked as expected by Prophecy - it thrown an
exception during the `checkPredictions()` call. Should be fixed now.
