### PR TITLE
Problem while doubling MongoDB ODM QueryBuilder

### DIFF
--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -74,7 +74,7 @@ class ClassCodeGenerator
                 if ('array' === $hint || 'callable' === $hint) {
                     $php .= $hint;
                 } else {
-                    $php .= class_exists($hint) || interface_exists($hint) ? '\\'.$hint : $hint;
+                    $php .= '\\'.$hint;
                 }
             }
 


### PR DESCRIPTION
Hello,

I'm having trouble mocking a `Doctrine\ODM\MongoDB\Query\Builder` object.
In fact, this class uses an optionnal dependency "GeoJson" to perform geo-related operation.

Problem appends when this package is not installed, prophecy will generate a non PHP standard compliant class (because one of the QB method is typehinted with a GeoJson class).

You can see the problem happening here: https://travis-ci.org/akeneo/pim-community-dev/jobs/21412381#L510

I'm not really convinced this is a prophecy issue, maybe it's more a mongodb-odm issue that should not bring hard-coupling between an optionnal dependency.

Anyway, I've found an easy fix in https://github.com/phpspec/prophecy/blob/master/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php#L77 which consits in always prepending `\\` to the argument's class, but I'm not sure I totally get the purpose of this line 77.

Could you enlight me, please?

Regards
