### PR TITLE
Added support for bypassing a constructor, if it's final

### DIFF
--- a/spec/Prophecy/Doubler/ClassPatch/DisableConstructorPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/DisableConstructorPatchSpec.php
@@ -33,6 +33,7 @@ class DisableConstructorPatchSpec extends ObjectBehavior
      */
     function it_makes_all_constructor_arguments_optional($class, $method, $arg1, $arg2)
     {
+        $class->isConstructorFinal()->willReturn(false);
         $class->hasMethod('__construct')->willReturn(true);
         $class->getMethod('__construct')->willReturn($method);
         $method->getArguments()->willReturn(array($arg1, $arg2));
@@ -50,10 +51,20 @@ class DisableConstructorPatchSpec extends ObjectBehavior
      */
     function it_creates_new_constructor_if_object_has_none($class)
     {
+        $class->isConstructorFinal()->willReturn(false);
         $class->hasMethod('__construct')->willReturn(false);
         $class->addMethod(Argument::type('Prophecy\Doubler\Generator\Node\MethodNode'))
             ->shouldBeCalled();
 
+        $this->apply($class);
+    }
+
+    /**
+     * @param \Prophecy\Doubler\Generator\Node\ClassNode $class
+     */
+    function it_ignores_constructor_creation_if_class_constructor_is_final($class)
+    {
+        $class->isConstructorFinal()->willReturn(true);
         $this->apply($class);
     }
 }

--- a/spec/Prophecy/Doubler/Generator/ClassMirrorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassMirrorSpec.php
@@ -25,6 +25,7 @@ class ClassMirrorSpec extends ObjectBehavior
         $class->isInterface()->willReturn(false);
         $class->isFinal()->willReturn(false);
         $class->getMethods(ReflectionMethod::IS_ABSTRACT)->willReturn(array());
+        $class->getMethods(ReflectionMethod::IS_FINAL)->willReturn(array());
         $class->getMethods(ReflectionMethod::IS_PUBLIC)->willReturn(array(
             $method1, $method2, $method3
         ));
@@ -73,6 +74,7 @@ class ClassMirrorSpec extends ObjectBehavior
         $class->isInterface()->willReturn(false);
         $class->isFinal()->willReturn(false);
         $class->getMethods(ReflectionMethod::IS_PUBLIC)->willReturn(array($method));
+        $class->getMethods(ReflectionMethod::IS_FINAL)->willReturn(array());
         $class->getMethods(ReflectionMethod::IS_ABSTRACT)->willReturn(array());
 
         $method->getParameters()->willReturn(array($parameter));
@@ -107,6 +109,7 @@ class ClassMirrorSpec extends ObjectBehavior
         $class->isInterface()->willReturn(false);
         $class->isFinal()->willReturn(false);
         $class->getMethods(ReflectionMethod::IS_ABSTRACT)->willReturn(array($method));
+        $class->getMethods(ReflectionMethod::IS_FINAL)->willReturn(array());
         $class->getMethods(ReflectionMethod::IS_PUBLIC)->willReturn(array());
 
         $method->isProtected()->willReturn(true);
@@ -134,6 +137,7 @@ class ClassMirrorSpec extends ObjectBehavior
         $class->isInterface()->willReturn(false);
         $class->isFinal()->willReturn(false);
         $class->getMethods(ReflectionMethod::IS_ABSTRACT)->willReturn(array($method));
+        $class->getMethods(ReflectionMethod::IS_FINAL)->willReturn(array());
         $class->getMethods(ReflectionMethod::IS_PUBLIC)->willReturn(array());
 
         $method->isProtected()->willReturn(true);
@@ -168,6 +172,7 @@ class ClassMirrorSpec extends ObjectBehavior
         $class->isInterface()->willReturn(false);
         $class->isFinal()->willReturn(false);
         $class->getMethods(ReflectionMethod::IS_ABSTRACT)->willReturn(array());
+        $class->getMethods(ReflectionMethod::IS_FINAL)->willReturn(array());
         $class->getMethods(ReflectionMethod::IS_PUBLIC)->willReturn(array($method));
 
         $method->getName()->willReturn('methodWithArgs');
@@ -240,6 +245,7 @@ class ClassMirrorSpec extends ObjectBehavior
         $class->isInterface()->willReturn(false);
         $class->isFinal()->willReturn(false);
         $class->getMethods(ReflectionMethod::IS_ABSTRACT)->willReturn(array());
+        $class->getMethods(ReflectionMethod::IS_FINAL)->willReturn(array());
         $class->getMethods(ReflectionMethod::IS_PUBLIC)->willReturn(array($method));
 
         $method->getName()->willReturn('methodWithArgs');
@@ -302,6 +308,7 @@ class ClassMirrorSpec extends ObjectBehavior
         $class->isInterface()->willReturn(false);
         $class->isFinal()->willReturn(false);
         $class->getMethods(ReflectionMethod::IS_ABSTRACT)->willReturn(array());
+        $class->getMethods(ReflectionMethod::IS_FINAL)->willReturn(array());
         $class->getMethods(ReflectionMethod::IS_PUBLIC)->willReturn(array($method));
 
         $method->isFinal()->willReturn(true);
@@ -309,6 +316,27 @@ class ClassMirrorSpec extends ObjectBehavior
 
         $classNode = $this->reflect($class, array());
         $classNode->getMethods()->shouldHaveCount(0);
+    }
+
+    /**
+     * @param ReflectionClass  $class
+     * @param ReflectionMethod $method
+     */
+    function it_detects_final_constructor($class, $method)
+    {
+        $class->getName()->willReturn('Custom\ClassName');
+        $class->isInterface()->willReturn(false);
+        $class->isFinal()->willReturn(false);
+        $class->getMethods(ReflectionMethod::IS_ABSTRACT)->willReturn(array());
+        $class->getMethods(ReflectionMethod::IS_FINAL)->willReturn(array($method));
+        $class->getMethods(ReflectionMethod::IS_PUBLIC)->willReturn(array());
+
+        $method->isFinal()->willReturn(true);
+        $method->getName()->willReturn('__construct');
+
+        $classNode = $this->reflect($class, array());
+        $classNode->getMethods()->shouldHaveCount(0);
+        $classNode->isConstructorFinal()->shouldReturn(true);
     }
 
     /**
@@ -387,6 +415,7 @@ class ClassMirrorSpec extends ObjectBehavior
         $class->isInterface()->willReturn(false);
         $class->isFinal()->willReturn(false);
         $class->getMethods(ReflectionMethod::IS_ABSTRACT)->willReturn(array());
+        $class->getMethods(ReflectionMethod::IS_FINAL)->willReturn(array());
         $class->getMethods(ReflectionMethod::IS_PUBLIC)->willReturn(array($method1, $method2, $method3));
 
         $method1->getName()->willReturn('_getName');
@@ -426,6 +455,7 @@ class ClassMirrorSpec extends ObjectBehavior
         $class->isInterface()->willReturn(false);
         $class->isFinal()->willReturn(false);
         $class->getMethods(ReflectionMethod::IS_ABSTRACT)->willReturn(array());
+        $class->getMethods(ReflectionMethod::IS_FINAL)->willReturn(array());
         $class->getMethods(ReflectionMethod::IS_PUBLIC)->willReturn(array($method));
 
         $method->getName()->willReturn('__toString');

--- a/src/Prophecy/Doubler/ClassPatch/DisableConstructorPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/DisableConstructorPatch.php
@@ -41,6 +41,10 @@ class DisableConstructorPatch implements ClassPatchInterface
      */
     public function apply(ClassNode $node)
     {
+        if ($node->isConstructorFinal()) {
+            return;
+        }
+
         if (!$node->hasMethod('__construct')) {
             $node->addMethod(new MethodNode('__construct', ''));
 

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -102,6 +102,12 @@ class ClassMirror
             $this->reflectMethodToNode($method, $node);
         }
 
+        foreach ($class->getMethods(ReflectionMethod::IS_FINAL) as $method) {
+            if ('__construct' === $method->getName()) {
+                $node->setConstructorIsFinal(true);
+            }
+        }
+
         foreach ($class->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
             if (0 === strpos($method->getName(), '_')
                 && !in_array($method->getName(), self::$reflectableMethods)) {

--- a/src/Prophecy/Doubler/Generator/Node/ClassNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/ClassNode.php
@@ -21,6 +21,7 @@ use Prophecy\Exception\InvalidArgumentException;
 class ClassNode
 {
     private $parentClass = 'stdClass';
+    private $constructorIsFinal = false;
     private $interfaces  = array();
     private $properties  = array();
 
@@ -28,6 +29,24 @@ class ClassNode
      * @var MethodNode[]
      */
     private $methods     = array();
+
+    /**
+     * @return boolean
+     */
+    public function isConstructorFinal()
+    {
+        return $this->constructorIsFinal;
+    }
+
+    /**
+     * @param boolean $constructorIsFinal
+     */
+    public function setConstructorIsFinal($constructorIsFinal)
+    {
+        $this->constructorIsFinal = $constructorIsFinal;
+
+        return $this;
+    }
 
     public function getParentClass()
     {


### PR DESCRIPTION
When creating a double of a class that has the constructor defined as final, we just ignore it, to avoid a fatal error about overriding a final constructor. An example of this problem occurs when double'ing Phalcon's Model classes.
