### PR TITLE
Feature/magic method arguments

### DIFF
--- a/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
@@ -4,6 +4,7 @@ namespace spec\Prophecy\Doubler\ClassPatch;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Prophecy\Doubler\Generator\Node\ArgumentNode;
 use Prophecy\Doubler\Generator\Node\MethodNode;
 
 class MagicCallPatchSpec extends ObjectBehavior
@@ -33,6 +34,24 @@ class MagicCallPatchSpec extends ObjectBehavior
         $this->apply($node);
     }
 
+    /**
+     * @param \Prophecy\Doubler\Generator\Node\ClassNode $node
+     */
+    function it_discovers_api_with_parameters_using_phpdoc($node)
+    {
+        $node->getParentClass()->willReturn('spec\Prophecy\Doubler\ClassPatch\MagicalParametrizedApi');
+
+        $method = new MethodNode('parametrizedMethod');
+        $method->addArgument(new ArgumentNode('param'));
+        $argumentWithDefaultValue = new ArgumentNode('param');
+        $argumentWithDefaultValue->setDefault('value');
+        $method->addArgument($argumentWithDefaultValue);
+        $method->addArgument($argumentWithDefaultValue);
+        $node->addMethod($method)->shouldBeCalled();
+
+        $this->apply($node);
+    }
+
     function it_has_50_priority()
     {
         $this->getPriority()->shouldReturn(50);
@@ -43,6 +62,20 @@ class MagicCallPatchSpec extends ObjectBehavior
  * @method void undefinedMethod()
  */
 class MagicalApi
+{
+    /**
+     * @return void
+     */
+    public function definedMethod()
+    {
+
+    }
+}
+
+/**
+ * @method void parametrizedMethod($param, $param = 'value', $param = "value")
+ */
+class MagicalParametrizedApi
 {
     /**
      * @return void

--- a/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
@@ -60,6 +60,7 @@ class MagicCallPatchSpec extends ObjectBehavior
 
 /**
  * @method void undefinedMethod()
+ * @method void definedMethod()
  */
 class MagicalApi
 {

--- a/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
@@ -50,14 +50,17 @@ class MagicCallPatch implements ClassPatchInterface
         $tagList = $phpdoc->getTagsByName('method');
 
         foreach($tagList as $tag) {
-            $methodNode = new MethodNode($tag->getMethodName());
-            $methodNode->setStatic($tag->isStatic());
+            $methodName = $tag->getMethodName();
+            if (!$reflectionClass->hasMethod($methodName)) {
+                $methodNode = new MethodNode($methodName);
+                $methodNode->setStatic($tag->isStatic());
 
-            foreach ($tag->getArguments() as $argument) {
-                $methodNode->addArgument($this->parseArgument($argument));
+                foreach ($tag->getArguments() as $argument) {
+                    $methodNode->addArgument($this->parseArgument($argument));
+                }
+
+                $node->addMethod($methodNode);
             }
-
-            $node->addMethod($methodNode);
         }
     }
 

--- a/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
@@ -53,8 +53,30 @@ class MagicCallPatch implements ClassPatchInterface
             $methodNode = new MethodNode($tag->getMethodName());
             $methodNode->setStatic($tag->isStatic());
 
+            foreach ($tag->getArguments() as $argument) {
+                $methodNode->addArgument($this->parseArgument($argument));
+            }
+
             $node->addMethod($methodNode);
         }
+    }
+
+    /**
+     * @param array $argument
+     * @return ArgumentNode
+     */
+    protected function parseArgument(array $argument) {
+        $eqPos = array_search('=', $argument);
+        $optional = $eqPos !== false;
+        $name = $optional ? $argument[$eqPos - 1] : end($argument);
+
+        $argumentNode = new ArgumentNode(ltrim($name, '$'));
+
+        if ($optional && isset($argument[$eqPos + 1])) {
+            $argumentNode->setDefault(trim($argument[$eqPos + 1], "'\""));
+        }
+
+        return $argumentNode;
     }
 
     /**


### PR DESCRIPTION
This adds support for arguments in magic methods + solves issue when current or its parents has normal method and also *method* tag (example why its useful would be to get correct return type in PHPStorm)

Argument parsing still lacks typehinting support, but I'm not sure its needed....