### PR TITLE
[RFC] support for generators

### DIFF
--- a/spec/Prophecy/Doubler/ClassPatch/GeneratorPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/GeneratorPatchSpec.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace spec\Prophecy\Doubler\ClassPatch;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class GeneratorPatchSpec extends ObjectBehavior
+{
+    function it_is_a_patch()
+    {
+        $this->shouldBeAnInstanceOf('Prophecy\Doubler\ClassPatch\ClassPatchInterface');
+    }
+
+    /**
+     * @param \Prophecy\Doubler\Generator\Node\ClassNode $node
+     */
+    function it_supports_class_that_implements_only_Generator($node)
+    {
+        $node->getParentClass()->willReturn('Generator');
+
+        $this->supports($node)->shouldReturn(true);
+    }
+
+    /**
+     * @param \Prophecy\Doubler\Generator\Node\ClassNode $node
+     */
+    function it_does_not_support_class_that_implements_something_else($node)
+    {
+        $node->getParentClass()->willReturn('Traversable');
+
+        $this->supports($node)->shouldReturn(false);
+    }
+
+    function it_has_200_priority()
+    {
+        $this->getPriority()->shouldReturn(200);
+    }
+
+    /**
+     * @param \Prophecy\Doubler\Generator\Node\ClassNode $node
+     */
+    function it_forces_node_to_implement_Generator($node)
+    {
+        $node->addMethod(Argument::type('Prophecy\Doubler\Generator\Node\MethodNode'))->willReturn(null);
+
+        $this->apply($node);
+    }
+
+    function it_actually_works_IRL($node)
+    {
+        $this->beAnInstanceOf('spec\Prophecy\Doubler\ClassPatch\Test');
+        $this->test()->shouldIterateLike(array_combine(range(0, 100), array_map(function($i) { return $i * 2; }, range(0, 100))));
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'iterateLike' => function($subject, $expect) {
+                return $expect == iterator_to_array($subject);
+            },
+        ];
+    }
+}
+
+class Test
+{
+    public function test()
+    {
+        foreach (range(0, 100) as $i) {
+            yield $i => $i * 2;
+        }
+    }
+}

--- a/src/Prophecy/Doubler/ClassPatch/GeneratorPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/GeneratorPatch.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Prophecy\Doubler\ClassPatch;
+
+use Prophecy\Doubler\Generator\Node\ClassNode;
+use Prophecy\Doubler\Generator\Node\MethodNode;
+
+/**
+ * @author Florian Klein <florian.klein@free.fr>
+ */
+class GeneratorPatch implements ClassPatchInterface
+{
+    /**
+     * @param ClassNode $node
+     *
+     * @return bool
+     */
+    public function supports(ClassNode $node)
+    {
+        return $node->getParentClass() === 'Generator';
+    }
+
+    /**
+     * Forces class to implement Iterator interface.
+     *
+     * @param ClassNode $node
+     */
+    public function apply(ClassNode $node)
+    {
+        foreach (array('current', 'key', 'next', 'rewind', 'valid', 'send', 'throw') as $name) {
+            $node->addMethod(new MethodNode($name));
+        }
+    }
+
+    /**
+     * Returns patch priority, which determines when patch will be applied.
+     *
+     * @return int Priority number (higher - earlier)
+     */
+    public function getPriority()
+    {
+        return 200;
+    }
+}


### PR DESCRIPTION
I'm not even sure if this couldn't be applied to Iterators in general, or if it's the correct approach, but at least it resolves parts of the problem of phpspec/phpspec#379.

Also, custom phpspec matchers have to be used in order to check array like stuff.
