### PR TITLE
Add support for DirectoryIterators

### DIFF
--- a/spec/Prophecy/Doubler/ClassPatch/SplFileInfoPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/SplFileInfoPatchSpec.php
@@ -51,6 +51,7 @@ class SplFileInfoPatchSpec extends ObjectBehavior
     {
         $node->hasMethod('__construct')->willReturn(false);
         $node->addMethod(Argument::any())->shouldBeCalled();
+        $node->getParentClass()->shouldBeCalled();
 
         $this->apply($node);
     }
@@ -63,9 +64,28 @@ class SplFileInfoPatchSpec extends ObjectBehavior
     {
         $node->hasMethod('__construct')->willReturn(true);
         $node->getMethod('__construct')->willReturn($method);
+        $node->getParentClass()->shouldBeCalled();
 
         $method->useParentCode()->shouldBeCalled();
 
         $this->apply($node);
     }
+
+    /**
+     * @param \Prophecy\Doubler\Generator\Node\ClassNode  $node
+     * @param \Prophecy\Doubler\Generator\Node\MethodNode $method
+     */
+    function it_should_not_supply_a_file_for_a_directory_iterator($node, $method)
+    {
+        $node->hasMethod('__construct')->willReturn(true);
+        $node->getMethod('__construct')->willReturn($method);
+        $node->getParentClass()->willReturn('DirectoryIterator');
+
+        $method->setCode(Argument::that(function($value) {
+            return strpos($value, '.php') === false;
+        }))->shouldBeCalled();
+
+        $this->apply($node);
+    }
+
 }

--- a/src/Prophecy/Doubler/ClassPatch/SplFileInfoPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/SplFileInfoPatch.php
@@ -54,6 +54,11 @@ class SplFileInfoPatch implements ClassPatchInterface
             $node->addMethod($constructor);
         }
 
+        if ($this->nodeIsDirectoryIterator($node)) {
+            $constructor->setCode('return parent::__construct("' . __DIR__ . '");');
+            return;
+        }
+
         $constructor->useParentCode();
     }
 
@@ -65,5 +70,16 @@ class SplFileInfoPatch implements ClassPatchInterface
     public function getPriority()
     {
         return 50;
+    }
+
+    /**
+     * @param ClassNode $node
+     * @return boolean
+     */
+    private function nodeIsDirectoryIterator(ClassNode $node)
+    {
+        $parent = $node->getParentClass();
+        return 'DirectoryIterator' === $parent
+            || is_subclass_of($parent, 'DirectoryIterator');
     }
 }


### PR DESCRIPTION
The current SplFileInfoPatch does not work with DirectoryIterator and its children, because DirectoryIterator requires that the first constructor argument is a directory not a file. This PR adds a check to SplFileInfoPatch that will call the parent constructor with a directory instead of a file when required.
