### PR TITLE
Add support for SplFileObject

### DIFF
--- a/spec/Prophecy/Doubler/ClassPatch/SplFileObjectPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/SplFileObjectPatchSpec.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace spec\Prophecy\Doubler\ClassPatch;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class SplFileObjectPatchSpec extends ObjectBehavior
+{
+    function it_is_a_patch()
+    {
+        $this->shouldBeAnInstanceOf('Prophecy\Doubler\ClassPatch\ClassPatchInterface');
+    }
+
+    function its_priority_is_higher_than_spl_file_info_patch()
+    {
+        $this->getPriority()->shouldReturn(40);
+    }
+
+    /**
+     * @param \Prophecy\Doubler\Generator\Node\ClassNode $node
+     */
+    function it_does_not_support_nodes_without_parent_class($node)
+    {
+        $node->getParentClass()->willReturn('stdClass');
+        $this->supports($node)->shouldReturn(false);
+    }
+
+    /**
+     * @param \Prophecy\Doubler\Generator\Node\ClassNode $node
+     */
+    function it_supports_nodes_with_SplObjectObject_as_parent_class($node)
+    {
+        $node->getParentClass()->willReturn('SplFileObject');
+        $this->supports($node)->shouldReturn(true);
+    }
+
+    /**
+     * @param \Prophecy\Doubler\Generator\Node\ClassNode $node
+     */
+    function it_supports_nodes_with_derivative_of_SplFileObject_as_parent_class($node)
+    {
+        $node->getParentClass()->willReturn('SplFileObject');
+        $this->supports($node)->shouldReturn(true);
+    }
+
+    /**
+     * @param \Prophecy\Doubler\Generator\Node\ClassNode $node
+     */
+    function it_adds_a_method_to_node_if_not_exists($node)
+    {
+        $node->hasMethod('__construct')->willReturn(false);
+        $node->addMethod(Argument::any())->shouldBeCalled();
+        $node->getParentClass()->shouldBeCalled();
+
+        $this->apply($node);
+    }
+
+    /**
+     * @param \Prophecy\Doubler\Generator\Node\ClassNode  $node
+     * @param \Prophecy\Doubler\Generator\Node\MethodNode $method
+     */
+    function it_updates_existing_method_if_found($node, $method)
+    {
+        $node->hasMethod('__construct')->willReturn(true);
+        $node->getMethod('__construct')->willReturn($method);
+        $node->getParentClass()->shouldBeCalled();
+
+        $this->apply($node);
+    }
+}

--- a/src/Prophecy/Doubler/ClassPatch/SplFileObjectPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/SplFileObjectPatch.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Prophecy\Doubler\ClassPatch;
+
+use Prophecy\Doubler\Generator\Node\ClassNode;
+use Prophecy\Doubler\Generator\Node\MethodNode;
+
+/**
+ * SplFileObject patch.
+ * Makes SplFileObject and derivative classes usable with Prophecy.
+ * By overriding default values which prevent SplFileObject being instantiated
+ *
+ * @author Artur Wielogorski <wodor@wodor.net>
+ */
+class SplFileObjectPatch implements ClassPatchInterface
+{
+    /**
+     * Supports everything that extends SplFileInfo.
+     *
+     * @param ClassNode $node
+     *
+     * @return bool
+     */
+    public function supports(ClassNode $node)
+    {
+        if (null === $node->getParentClass()) {
+            return false;
+        }
+
+        return 'SplFileObject' === $node->getParentClass()
+        || is_subclass_of($node->getParentClass(), 'SplFileObject');
+    }
+
+    /**
+     * Updated constructor code to call parent one with dummy file argument.
+     *
+     * @param ClassNode $node
+     */
+    public function apply(ClassNode $node)
+    {
+        if ($node->hasMethod('__construct')) {
+            $constructor = $node->getMethod('__construct');
+        } else {
+            $constructor = new MethodNode('__construct');
+            $node->addMethod($constructor);
+        }
+
+        // FIXME find a proper way to find out if the construcor is overriden
+        // i.e compare list of arguments
+        if (is_subclass_of($node->getParentClass(), 'SplFileObject')) {
+            $constructor->useParentCode();
+            return;
+        }
+
+        $constructor->setCode('return parent::__construct("' . __FILE__ . '");');
+    }
+
+    /**
+     * Returns patch priority, which determines when patch will be applied.
+     *
+     * @return int Priority number (higher - earlier)
+     */
+    public function getPriority()
+    {
+        return 40;
+    }
+}

--- a/src/Prophecy/Prophet.php
+++ b/src/Prophecy/Prophet.php
@@ -51,6 +51,7 @@ class Prophet
         if (null === $doubler) {
             $doubler = new Doubler;
             $doubler->registerClassPatch(new ClassPatch\SplFileInfoPatch);
+            $doubler->registerClassPatch(new ClassPatch\SplFileObjectPatch);
             $doubler->registerClassPatch(new ClassPatch\TraversablePatch);
             $doubler->registerClassPatch(new ClassPatch\DisableConstructorPatch);
             $doubler->registerClassPatch(new ClassPatch\ProphecySubjectPatch);


### PR DESCRIPTION
Since the SplFileInfoPatch was opened to allow parameters of subclasses, internal children of SplFileInfo stoped working i.e  code like this 
```
    function it_test_spl_file_object(\SplFileObject $fileObject)
    {
        $this->foo()->shouldReturn('foo');
    }
```

generates 
```
  34  ! it test spl file object
      exception [exc:RuntimeException("SplFileObject::__construct() expects parameter 4 to be resource, null given")] has been thrown.
```

This PR is WIP, missing things: 
- support for `SplTempFileObject` should be added 
- smarter way of letting classes which inherit from `SplFileObject` and `SplTempFileObject`  to have arbitrary parameters in constructor 

