### PR TITLE
Set KeywordPatch to lower priority to check magic methods for keywords

### DIFF
--- a/spec/Prophecy/Doubler/ClassPatch/KeywordPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/KeywordPatchSpec.php
@@ -13,9 +13,9 @@ class KeywordPatchSpec extends ObjectBehavior
         $this->shouldBeAnInstanceOf('Prophecy\Doubler\ClassPatch\ClassPatchInterface');
     }
 
-    function its_priority_is_50()
+    function its_priority_is_49()
     {
-        $this->getPriority()->shouldReturn(50);
+        $this->getPriority()->shouldReturn(49);
     }
 
     /**

--- a/src/Prophecy/Doubler/ClassPatch/KeywordPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/KeywordPatch.php
@@ -52,7 +52,7 @@ class KeywordPatch implements ClassPatchInterface
      * @return int Priority number (higher - earlier)
      */
     public function getPriority() {
-        return 50;
+        return 49;
     }
 
     /**


### PR DESCRIPTION
Sets KeywordPatch to a lower priority than MagicCallPatch, so magic methods are filtered for keywords.