### PR TITLE
Add Argument::invoke() for testing callback arguments

### DIFF
--- a/spec/Prophecy/Argument/Token/InvokeTokenSpec.php
+++ b/spec/Prophecy/Argument/Token/InvokeTokenSpec.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace spec\Prophecy\Argument\Token;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Prophecy\Exception\InvalidArgumentException;
+
+class InvokeTokenSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(array());
+    }
+
+    function it_implements_TokenInterface()
+    {
+        $this->shouldBeAnInstanceOf('Prophecy\Argument\Token\TokenInterface');
+    }
+
+    function it_is_not_last()
+    {
+        $this->shouldNotBeLast();
+    }
+
+    function it_checks_if_argument_is_a_callback()
+    {
+        $this->shouldThrow(new InvalidArgumentException(
+            'Callable expected as an argument to CallbackToken, but got integer.'
+        ))->duringScoreArgument(5);
+    }
+
+    function it_scores_argument_as_3_return_value_is_not_checked()
+    {
+        $this->scoreArgument(function () {})->shouldReturn(3);
+    }
+
+    function it_scores_argument_as_3_return_value_correct()
+    {
+        $this->beConstructedWith(array(), true, 10);
+
+        $this->scoreArgument(function () { return 10; })->shouldReturn(3);
+    }
+
+    function it_scores_argument_as_false_return_value_incorrect()
+    {
+        $this->beConstructedWith(array(), true, 'correct');
+
+        $this->scoreArgument(function () { return 'incorrect'; })->shouldReturn(false);
+    }
+
+    function it_invokes_argument(Spy $spy)
+    {
+        $this->scoreArgument(function () use ($spy) {
+            $spy->getWrappedObject()->action();
+        });
+
+        $spy->action()->shouldHaveBeenCalled();
+    }
+
+    function it_invokes_argument_with_argument_list(Spy $spy)
+    {
+        $this->beConstructedWith(array(11, 'test'));
+
+        $this->scoreArgument(function ($arg1, $arg2) use ($spy) {
+            $spy->getWrappedObject()->actionArgs($arg1, $arg2);
+        });
+
+        $spy->actionArgs(11, 'test')->shouldHaveBeenCalled();
+    }
+
+    function it_generates_proper_string_representation_for_integer()
+    {
+        $this->beConstructedWith(array(42));
+        $this->__toString()->shouldReturn('invoke(42)');
+    }
+
+    function it_generates_proper_string_representation_for_string()
+    {
+        $this->beConstructedWith(array('some string'));
+        $this->__toString()->shouldReturn('invoke("some string")');
+    }
+
+    function it_generates_single_line_representation_for_multiline_string()
+    {
+        $this->beConstructedWith(array("some\nstring"));
+        $this->__toString()->shouldReturn('invoke("some\\nstring")');
+    }
+
+    function it_generates_proper_string_representation_for_double()
+    {
+        $this->beConstructedWith(array(42.3));
+        $this->__toString()->shouldReturn('invoke(42.3)');
+    }
+
+    function it_generates_proper_string_representation_for_boolean_true()
+    {
+        $this->beConstructedWith(array(true));
+        $this->__toString()->shouldReturn('invoke(true)');
+    }
+
+    function it_generates_proper_string_representation_for_boolean_false()
+    {
+        $this->beConstructedWith(array(false));
+        $this->__toString()->shouldReturn('invoke(false)');
+    }
+
+    function it_generates_proper_string_representation_for_null()
+    {
+        $this->beConstructedWith(array(null));
+        $this->__toString()->shouldReturn('invoke(null)');
+    }
+
+    function it_generates_proper_string_representation_for_empty_array()
+    {
+        $this->beConstructedWith(array(array()));
+        $this->__toString()->shouldReturn('invoke([])');
+    }
+
+    function it_generates_proper_string_representation_for_array()
+    {
+        $this->beConstructedWith(array(array('zet', 42)));
+        $this->__toString()->shouldReturn('invoke(["zet", 42])');
+    }
+
+    function it_generates_proper_string_representation_for_resource()
+    {
+        $resource = fopen(__FILE__, 'r');
+        $this->beConstructedWith(array($resource));
+        $this->__toString()->shouldReturn('invoke(stream:'.$resource.')');
+    }
+
+    function it_generates_proper_string_representation_for_object($object)
+    {
+        $objHash = sprintf('%s:%s',
+            get_class($object->getWrappedObject()),
+            spl_object_hash($object->getWrappedObject())
+        );
+
+        $this->beConstructedWith(array($object));
+        $this->__toString()->shouldReturn("invoke($objHash Object (\n    'objectProphecy' => Prophecy\Prophecy\ObjectProphecy Object (*Prophecy*)\n))");
+    }
+
+    function it_generates_proper_string_representation_for_multiple_arguments()
+    {
+        $this->beConstructedWith(array(5, 'test', true, false));
+
+        $this->__toString()->shouldReturn('invoke(5, "test", true, false)');
+    }
+
+    function it_generates_proper_string_representation_when_result_is_expected()
+    {
+        $this->beConstructedWith(array(5, 'test', true, false), true, 22);
+
+        $this->__toString()->shouldReturn('22 == invoke(5, "test", true, false)');
+    }
+}
+
+interface Spy
+{
+    public function action();
+
+    public function actionArgs($arg1, $arg2);
+}

--- a/spec/Prophecy/ArgumentSpec.php
+++ b/spec/Prophecy/ArgumentSpec.php
@@ -73,6 +73,20 @@ class ArgumentSpec extends ObjectBehavior
         $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\IdenticalValueToken');
     }
 
+    function it_has_a_shortcut_for_invoke_token()
+    {
+        $token = $this->invoke(array('value1', 2));
+        $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\InvokeToken');
+        $token->__toString()->shouldReturn('invoke("value1", 2)');
+    }
+
+    function it_has_a_shortcut_for_invoke_token_with_expected_result()
+    {
+        $token = $this->invoke(array('value'), 'result');
+        $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\InvokeToken');
+        $token->__toString()->shouldReturn('"result" == invoke("value")');
+    }
+
     function it_has_a_shortcut_for_array_entry_token_matching_any_key()
     {
         $token = $this->containing('value');

--- a/src/Prophecy/Argument.php
+++ b/src/Prophecy/Argument.php
@@ -195,4 +195,17 @@ class Argument
     {
         return new Token\IdenticalValueToken($value);
     }
+
+    /**
+     * Invoke a callback arguement with supplied values
+     *
+     * @param mixed[] $arguments
+     * @param mixed   $expectedResult
+     *
+     * @return Token\InvokeToken
+     */
+    public function invoke(array $arguments = array(), $expectedResult = null)
+    {
+        return new Token\InvokeToken($arguments, func_num_args() === 2, $expectedResult);
+    }
 }

--- a/src/Prophecy/Argument/Token/InvokeToken.php
+++ b/src/Prophecy/Argument/Token/InvokeToken.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Prophecy\Argument\Token;
+
+use Prophecy\Util\StringUtil;
+use Prophecy\Exception\InvalidArgumentException;
+
+/**
+ * Invoke callback.
+ *
+ * @author Tom Oram <tom@x2k.co.uk>
+ */
+class InvokeToken implements TokenInterface
+{
+    /**
+     * @var array
+     */
+    private $arguments;
+
+    /**
+     * @var false
+     */
+    private $expectResult;
+
+    /**
+     * @var mixed
+     */
+    private $expectedResult;
+
+    /**
+     * @var StringUtil
+     */
+    private $util;
+
+    /**
+     * @param mixed[] $arguments
+     * @param bool    $expectResult
+     * @param mixed   $expectedResult
+     */
+    public function __construct(array $arguments, $expectResult = false, $expectedResult = null)
+    {
+        $this->arguments      = $arguments;
+        $this->expectResult   = $expectResult;
+        $this->expectedResult = $expectedResult;
+        $this->util           = new StringUtil();
+    }
+
+    /**
+     * Execute the callback with arguments and score 3 (same as AnyValueToken)
+     * if successful.
+     *
+     * @param callable $callback
+     *
+     * @return int|bool
+     */
+    public function scoreArgument($callback)
+    {
+        if (!is_callable($callback)) {
+            throw new InvalidArgumentException(sprintf(
+                'Callable expected as an argument to CallbackToken, but got %s.',
+                gettype($callback)
+            ));
+        }
+
+        $result = call_user_func_array($callback, $this->arguments);
+
+        $score = 3;
+
+        if ($this->expectResult && $result != $this->expectedResult) {
+            $score = false;
+        }
+
+        return $score;
+    }
+
+    /**
+     * Returns false.
+     *
+     * @return bool
+     */
+    public function isLast()
+    {
+        return false;
+    }
+
+    /**
+     * Returns string representation for token.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return sprintf(
+            '%sinvoke(%s)',
+            $this->expectResult ? $this->util->stringify($this->expectedResult) . ' == ' : '',
+            $this->createArgumentString()
+        );
+    }
+
+    /**
+     * Returns string representation a list of values.
+     *
+     * @return string
+     */
+    private function createArgumentString()
+    {
+        return implode(', ', array_map(
+            array($this->util, 'stringify'),
+            $this->arguments
+        ));
+    }
+}


### PR DESCRIPTION
The idea here is to cause a callback argument to a mock to be invoked so that the contents of the callback can be tests. Example:

```php
<?php

function it_tests_callback(Collection $collection, Item $item)
{
    $collection->foreachItem(Argument::invoke([$item], 'success'))->willReturn();

    $this->execute($collection, 10);

    $item->action(10)->shouldHaveBeenCalled();
}

function execute($collection, $value)
{
    $collection->foreachItem(function ($item) use ($value) {
        $item->action($value);

        return 'success';
    });
}
```

I understand this could be controversial so I'm expecting some discussion.

Also I wasn't sure what score value to return so I just took the same as `AnyValueToken`? 