### PR TITLE
Use correct case when only 1 prediction was made

### DIFF
--- a/src/Prophecy/Prediction/NoCallsPrediction.php
+++ b/src/Prophecy/Prediction/NoCallsPrediction.php
@@ -51,15 +51,17 @@ class NoCallsPrediction implements PredictionInterface
             return;
         }
 
+        $verb = count($calls) === 1 ? 'was' : 'were';
+
         throw new UnexpectedCallsException(sprintf(
             "No calls expected that match:\n".
             "  %s->%s(%s)\n".
-            "but %d were made:\n%s",
-
+            "but %d %s made:\n%s",
             get_class($object->reveal()),
             $method->getMethodName(),
             $method->getArgumentsWildcard(),
             count($calls),
+            $verb,
             $this->util->stringifyCalls($calls)
         ), $method, $calls);
     }


### PR DESCRIPTION
Currently:

````
    but 1 were made:
      - flush() @ src/Sulu/Component/HttpCache/EventSubscriber/KernelSubscriber.php:109
````

with this PR:

````
    but 1 was made:
      - flush() @ src/Sulu/Component/HttpCache/EventSubscriber/KernelSubscriber.php:109
````