### PR TITLE
Don't allow HHVM failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ language: php
 
 php: [5.3, 5.4, 5.5, hhvm, hhvm-nightly]
 
-matrix:
-  allow_failures:
-    - php: hhvm
-    - php: hhvm-nightly
-
 before_script:
   - composer self-update
   - composer install --dev --prefer-source


### PR DESCRIPTION
Seems HHVM hasn't been failing for some months now.