### PR TITLE
Record arguments used when method not found exception is thrown

### DIFF
--- a/spec/Prophecy/Exception/Doubler/MethodNotFoundExceptionSpec.php
+++ b/spec/Prophecy/Exception/Doubler/MethodNotFoundExceptionSpec.php
@@ -9,7 +9,7 @@ class MethodNotFoundExceptionSpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith('', 'User', 'getName');
+        $this->beConstructedWith('', 'User', 'getName', array(1,2,3));
     }
 
     function it_is_DoubleException()
@@ -25,5 +25,16 @@ class MethodNotFoundExceptionSpec extends ObjectBehavior
     function it_has_classnamej()
     {
         $this->getClassname()->shouldReturn('User');
+    }
+
+    function it_has_an_arguments_list()
+    {
+        $this->getArguments()->shouldReturn(array(1,2,3));
+    }
+
+    function it_has_a_default_empty_argument_list()
+    {
+        $this->beConstructedWith('', 'User', 'getName');
+        $this->getArguments()->shouldReturn(array());
     }
 }

--- a/src/Prophecy/Exception/Doubler/MethodNotFoundException.php
+++ b/src/Prophecy/Exception/Doubler/MethodNotFoundException.php
@@ -13,10 +13,18 @@ namespace Prophecy\Exception\Doubler;
 
 class MethodNotFoundException extends DoubleException
 {
-    private $classname;
-    private $methodName;
     /**
-     * @var array|null
+     * @var string
+     */
+    private $classname;
+
+    /**
+     * @var string
+     */
+    private $methodName;
+
+    /**
+     * @var array
      */
     private $arguments;
 
@@ -26,7 +34,7 @@ class MethodNotFoundException extends DoubleException
      * @param string $methodName
      * @param array  $arguments
      */
-    public function __construct($message, $classname, $methodName, $arguments = array())
+    public function __construct($message, $classname, $methodName, array $arguments = array())
     {
         parent::__construct($message);
 

--- a/src/Prophecy/Exception/Doubler/MethodNotFoundException.php
+++ b/src/Prophecy/Exception/Doubler/MethodNotFoundException.php
@@ -15,18 +15,24 @@ class MethodNotFoundException extends DoubleException
 {
     private $classname;
     private $methodName;
+    /**
+     * @var array|null
+     */
+    private $arguments;
 
     /**
      * @param string $message
      * @param string $classname
      * @param string $methodName
+     * @param array  $arguments
      */
-    public function __construct($message, $classname, $methodName)
+    public function __construct($message, $classname, $methodName, $arguments = array())
     {
         parent::__construct($message);
 
         $this->classname  = $classname;
         $this->methodName = $methodName;
+        $this->arguments = $arguments;
     }
 
     public function getClassname()
@@ -37,5 +43,10 @@ class MethodNotFoundException extends DoubleException
     public function getMethodName()
     {
         return $this->methodName;
+    }
+
+    public function getArguments()
+    {
+        return $this->arguments;
     }
 }

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -47,7 +47,7 @@ class MethodProphecy
         $double = $objectProphecy->reveal();
         if (!method_exists($double, $methodName)) {
             throw new MethodNotFoundException(sprintf(
-                'Method `%s::%s()` is not defined.', get_class($double), $methodName
+                'Method `%s::%s()` is not defined.', get_class($double), $methodName, $arguments ?: array()
             ), get_class($double), $methodName);
         }
 


### PR DESCRIPTION
This will be useful when handling these exceptions in PhpSpec (e.g. by generating a method)