### PR TITLE
ReturnArgumentPromise should accept optional index argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ argument - `'123'` to always return `'value'`. But that's only for this
 promise, there's plenty others you can use:
 
 - `ReturnPromise` or `->willReturn(1)` - returns a value from a method call
-- `ReturnArgumentPromise` or `->willReturnArgument($argument)` - returns the nth method argument from call
+- `ReturnArgumentPromise` or `->willReturnArgument($index)` - returns the nth method argument from call
 - `ThrowPromise` or `->willThrow` - causes the method to throw specific exception
 - `CallbackPromise` or `->will($callback)` - gives you a quick way to define your own custom logic
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ argument - `'123'` to always return `'value'`. But that's only for this
 promise, there's plenty others you can use:
 
 - `ReturnPromise` or `->willReturn(1)` - returns a value from a method call
-- `ReturnArgumentPromise` or `->willReturnArgument($argN)` - returns the nth method argument from call
+- `ReturnArgumentPromise` or `->willReturnArgument($argument)` - returns the nth method argument from call
 - `ThrowPromise` or `->willThrow` - causes the method to throw specific exception
 - `CallbackPromise` or `->will($callback)` - gives you a quick way to define your own custom logic
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ argument - `'123'` to always return `'value'`. But that's only for this
 promise, there's plenty others you can use:
 
 - `ReturnPromise` or `->willReturn(1)` - returns a value from a method call
-- `ReturnArgumentPromise` or `->willReturnArgument()` - returns the first method argument from call
+- `ReturnArgumentPromise` or `->willReturnArgument($argN)` - returns the nth method argument from call
 - `ThrowPromise` or `->willThrow` - causes the method to throw specific exception
 - `CallbackPromise` or `->will($callback)` - gives you a quick way to define your own custom logic
 

--- a/spec/Prophecy/Promise/ReturnArgumentPromiseSpec.php
+++ b/spec/Prophecy/Promise/ReturnArgumentPromiseSpec.php
@@ -28,4 +28,14 @@ class ReturnArgumentPromiseSpec extends ObjectBehavior
     {
         $this->execute(array(), $object, $method)->shouldReturn(null);
     }
+
+    /**
+     * @param \Prophecy\Prophecy\ObjectProphecy $object
+     * @param \Prophecy\Prophecy\MethodProphecy $method
+     */
+    function it_should_return_nth_argument_if_provided($object, $method)
+    {
+        $this->beConstructedWith(1);
+        $this->execute(array('one', 'two'), $object, $method)->shouldReturn('two');
+    }
 }

--- a/spec/Prophecy/Prophecy/MethodProphecySpec.php
+++ b/spec/Prophecy/Prophecy/MethodProphecySpec.php
@@ -102,6 +102,16 @@ class MethodProphecySpec extends ObjectBehavior
         $this->getPromise()->shouldBeAnInstanceOf('Prophecy\Promise\ReturnArgumentPromise');
     }
 
+    function it_adds_ReturnArgumentPromise_during_willReturnArgument_call_with_index_argument($objectProphecy)
+    {
+        $objectProphecy->addMethodProphecy($this)->willReturn(null);
+
+        $this->willReturnArgument(1);
+        $promise = $this->getPromise();
+        $promise->shouldBeAnInstanceOf('Prophecy\Promise\ReturnArgumentPromise');
+        $promise->execute(array('one', 'two'), $objectProphecy, $this)->shouldReturn('two');
+    }
+
     function it_adds_CallbackPromise_during_will_call_with_callback_argument($objectProphecy)
     {
         $objectProphecy->addMethodProphecy($this)->willReturn(null);

--- a/src/Prophecy/Promise/ReturnArgumentPromise.php
+++ b/src/Prophecy/Promise/ReturnArgumentPromise.php
@@ -25,24 +25,24 @@ class ReturnArgumentPromise implements PromiseInterface
     /**
      * @var int
      */
-    private $argument;
+    private $index;
 
     /**
      * Initializes callback promise.
      *
-     * @param int $argument The zero-indexed number of the argument to return
+     * @param int $index The zero-indexed number of the argument to return
      *
      * @throws \Prophecy\Exception\InvalidArgumentException
      */
-    public function __construct($argument = 0)
+    public function __construct($index = 0)
     {
-        if (!is_int($argument) || $argument < 0) {
+        if (!is_int($index) || $index < 0) {
             throw new InvalidArgumentException(
                 'Zero-based index expected as argument to ReturnArgumentPromise, but got %s.',
-                $argument
+                $index
             );
         }
-        $this->argument = $argument;
+        $this->index = $index;
     }
 
     /**
@@ -56,6 +56,6 @@ class ReturnArgumentPromise implements PromiseInterface
      */
     public function execute(array $args, ObjectProphecy $object, MethodProphecy $method)
     {
-        return count($args) > $this->argument ? $args[$this->argument] : null;
+        return count($args) > $this->index ? $args[$this->index] : null;
     }
 }

--- a/src/Prophecy/Promise/ReturnArgumentPromise.php
+++ b/src/Prophecy/Promise/ReturnArgumentPromise.php
@@ -11,6 +11,7 @@
 
 namespace Prophecy\Promise;
 
+use Prophecy\Exception\InvalidArgumentException;
 use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\Prophecy\MethodProphecy;
 
@@ -22,7 +23,30 @@ use Prophecy\Prophecy\MethodProphecy;
 class ReturnArgumentPromise implements PromiseInterface
 {
     /**
-     * Returns first argument if has one, null otherwise.
+     * @var int
+     */
+    private $argN;
+
+    /**
+     * Initializes callback promise.
+     *
+     * @param int $argN The zero-indexed number of the argument to return
+     *
+     * @throws \Prophecy\Exception\InvalidArgumentException
+     */
+    public function __construct($argN = 0)
+    {
+        if (!is_int($argN) || $argN < 0) {
+            throw new InvalidArgumentException(
+                'Zero-based index expected as argument to ReturnArgumentPromise, but got %s.',
+                $argN
+            );
+        }
+        $this->argN = $argN;
+    }
+
+    /**
+     * Returns nth argument if has one, null otherwise.
      *
      * @param array          $args
      * @param ObjectProphecy $object
@@ -32,6 +56,6 @@ class ReturnArgumentPromise implements PromiseInterface
      */
     public function execute(array $args, ObjectProphecy $object, MethodProphecy $method)
     {
-        return count($args) ? $args[0] : null;
+        return count($args) > $this->argN ? $args[$this->argN] : null;
     }
 }

--- a/src/Prophecy/Promise/ReturnArgumentPromise.php
+++ b/src/Prophecy/Promise/ReturnArgumentPromise.php
@@ -25,24 +25,24 @@ class ReturnArgumentPromise implements PromiseInterface
     /**
      * @var int
      */
-    private $argN;
+    private $argument;
 
     /**
      * Initializes callback promise.
      *
-     * @param int $argN The zero-indexed number of the argument to return
+     * @param int $argument The zero-indexed number of the argument to return
      *
      * @throws \Prophecy\Exception\InvalidArgumentException
      */
-    public function __construct($argN = 0)
+    public function __construct($argument = 0)
     {
-        if (!is_int($argN) || $argN < 0) {
+        if (!is_int($argument) || $argument < 0) {
             throw new InvalidArgumentException(
                 'Zero-based index expected as argument to ReturnArgumentPromise, but got %s.',
-                $argN
+                $argument
             );
         }
-        $this->argN = $argN;
+        $this->argument = $argument;
     }
 
     /**
@@ -56,6 +56,6 @@ class ReturnArgumentPromise implements PromiseInterface
      */
     public function execute(array $args, ObjectProphecy $object, MethodProphecy $method)
     {
-        return count($args) > $this->argN ? $args[$this->argN] : null;
+        return count($args) > $this->argument ? $args[$this->argument] : null;
     }
 }

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -140,13 +140,15 @@ class MethodProphecy
     /**
      * Sets return argument promise to the prophecy.
      *
+     * @param int $argN The zero-indexed number of the argument to return
+     *
      * @see Prophecy\Promise\ReturnArgumentPromise
      *
      * @return $this
      */
-    public function willReturnArgument()
+    public function willReturnArgument($argN = 0)
     {
-        return $this->will(new Promise\ReturnArgumentPromise);
+        return $this->will(new Promise\ReturnArgumentPromise($argN));
     }
 
     /**

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -140,15 +140,15 @@ class MethodProphecy
     /**
      * Sets return argument promise to the prophecy.
      *
-     * @param int $argument The zero-indexed number of the argument to return
+     * @param int $index The zero-indexed number of the argument to return
      *
      * @see Prophecy\Promise\ReturnArgumentPromise
      *
      * @return $this
      */
-    public function willReturnArgument($argument = 0)
+    public function willReturnArgument($index = 0)
     {
-        return $this->will(new Promise\ReturnArgumentPromise($argument));
+        return $this->will(new Promise\ReturnArgumentPromise($index));
     }
 
     /**

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -140,15 +140,15 @@ class MethodProphecy
     /**
      * Sets return argument promise to the prophecy.
      *
-     * @param int $argN The zero-indexed number of the argument to return
+     * @param int $argument The zero-indexed number of the argument to return
      *
      * @see Prophecy\Promise\ReturnArgumentPromise
      *
      * @return $this
      */
-    public function willReturnArgument($argN = 0)
+    public function willReturnArgument($argument = 0)
     {
-        return $this->will(new Promise\ReturnArgumentPromise($argN));
+        return $this->will(new Promise\ReturnArgumentPromise($argument));
     }
 
     /**


### PR DESCRIPTION
This adds an optional zero-based integer argument to `->willReturnArgument()` which allows
to specify the argument which should be returned.

The default behaviour of `ReturnArgumentPromise` is not changed, it will return the first
argument by default.