### PR TITLE
Avoiding abandoned packages "dflydev/markdown"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "phpdocumentor/reflection-docblock": "~2.0",
+        "phpdocumentor/reflection-docblock": "~2.0, >=2.0.1",
         "sebastian/comparator":              "~1.1",
         "doctrine/instantiator":             "^1.0.2"
     },


### PR DESCRIPTION
As `phpdocumentor/reflection-docblock` depends on the abandoned package `dflydev/markdown` until 2.0.1, this causes a warning in `composer update --prefer-lowest`.

The problem is my projects depends on `phpunit/phpunit: ~4.5` which depends on `phpspec/prophecy: ~1.3.1` which depends on `phpdocumentor/reflection-docblock: ~2.0` which depends on the abandoned package `dflydev/markdown`… Would this be enough to fix that chain?