### PR TITLE
Fix stringifying of hash containing one value

### DIFF
--- a/spec/Prophecy/Util/StringUtilSpec.php
+++ b/spec/Prophecy/Util/StringUtilSpec.php
@@ -51,6 +51,11 @@ class StringUtilSpec extends ObjectBehavior
         $this->stringify(array('zet', 42))->shouldReturn('["zet", 42]');
     }
 
+    function it_generates_proper_string_representation_for_hash_containing_one_value()
+    {
+        $this->stringify(array('ever' => 'zet'))->shouldReturn('["ever" => "zet"]');
+    }
+
     function it_generates_proper_string_representation_for_hash()
     {
         $this->stringify(array('ever' => 'zet', 52 => 'hey', 'num' => 42))->shouldReturn(

--- a/src/Prophecy/Util/StringUtil.php
+++ b/src/Prophecy/Util/StringUtil.php
@@ -31,7 +31,7 @@ class StringUtil
     public function stringify($value, $exportObject = true)
     {
         if (is_array($value)) {
-            if (range(0, count($value) - 1) == array_keys($value)) {
+            if (range(0, count($value) - 1) === array_keys($value)) {
                 return '['.implode(', ', array_map(array($this, __FUNCTION__), $value)).']';
             }
 


### PR DESCRIPTION
Equivalence operator is not strict enough.
The following code
```php
var_dump([0 => 0] == [0 => 'foo']);
```
outputs "true".

So, when we are trying to stringify ```['foo' => 'bar']```, hash is being stingified as array.

