### PR TITLE
Discover even Interface magic API not only Class

### DIFF
--- a/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
@@ -27,8 +27,12 @@ class MagicCallPatchSpec extends ObjectBehavior
     function it_discovers_api_using_phpdoc($node)
     {
         $node->getParentClass()->willReturn('spec\Prophecy\Doubler\ClassPatch\MagicalApi');
+        $node->hasMethod('undefinedMethod')->willReturn(false);
+        $node->hasMethod('undefinedInterfaceMethod')->willReturn(false);
+        $node->getInterfaces()->willReturn(['spec\Prophecy\Doubler\ClassPatch\MagicalInterface']);
 
         $node->addMethod(new MethodNode('undefinedMethod'))->shouldBeCalled();
+        $node->addMethod(new MethodNode('undefinedInterfaceMethod'))->shouldBeCalled();
 
         $this->apply($node);
     }
@@ -39,8 +43,12 @@ class MagicCallPatchSpec extends ObjectBehavior
     function it_ignores_existing_methods($node)
     {
         $node->getParentClass()->willReturn('spec\Prophecy\Doubler\ClassPatch\MagicalApiExtended');
+        $node->getInterfaces()->shouldBeCalled();
 
+        $node->hasMethod('undefinedMethod')->willReturn(false);
         $node->addMethod(new MethodNode('undefinedMethod'))->shouldBeCalled();
+
+        $node->hasMethod('definedMethod')->willReturn(true);
         $node->addMethod(new MethodNode('definedMethod'))->shouldNotBeCalled();
 
         $this->apply($node);
@@ -53,9 +61,16 @@ class MagicCallPatchSpec extends ObjectBehavior
 }
 
 /**
+ * @method void undefinedInterfaceMethod()
+ */
+interface MagicalInterface {
+
+}
+
+/**
  * @method void undefinedMethod()
  */
-class MagicalApi
+class MagicalApi implements MagicalInterface
 {
     /**
      * @return void

--- a/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
@@ -29,7 +29,7 @@ class MagicCallPatchSpec extends ObjectBehavior
         $node->getParentClass()->willReturn('spec\Prophecy\Doubler\ClassPatch\MagicalApi');
         $node->hasMethod('undefinedMethod')->willReturn(false);
         $node->hasMethod('undefinedInterfaceMethod')->willReturn(false);
-        $node->getInterfaces()->willReturn(['spec\Prophecy\Doubler\ClassPatch\MagicalInterface']);
+        $node->getInterfaces()->willReturn(array('spec\Prophecy\Doubler\ClassPatch\MagicalInterface'));
 
         $node->addMethod(new MethodNode('undefinedMethod'))->shouldBeCalled();
         $node->addMethod(new MethodNode('undefinedInterfaceMethod'))->shouldBeCalled();

--- a/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
@@ -43,7 +43,7 @@ class MagicCallPatch implements ClassPatchInterface
     {
         $this->attach($node, $node->getParentClass());
 
-        $interfaces = $node->getInterfaces() ?: [];
+        $interfaces = $node->getInterfaces() ?: array();
         foreach ($interfaces as $interfaceName) {
             $this->attach($node, $interfaceName);
         }

--- a/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
@@ -53,9 +53,9 @@ class MagicCallPatch implements ClassPatchInterface
      * Discovers and attaches Magical API to node
      *
      * @param ClassNode $node
-     * @param $className
+     * @param string $className
      */
-    protected function attach(ClassNode $node, $className)
+    private function attach(ClassNode $node, $className)
     {
         $reflectionClass = new \ReflectionClass($className);
         $phpdoc = new DocBlock($reflectionClass->getDocComment());


### PR DESCRIPTION
MagicCallPatch ambition is to discover magic APIs. It does it well on classes but ignores interfaces and that is a problem when you mock them.