### PR TITLE
Updating changelog for 1.4.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,18 @@
+1.4.0 / 2015-x-x
+================
+
+  * Fixed errors in return type phpdocs (thanks @sobit)
+  * Fixed stringifying of hash containing one value (thanks @avant1)
+  * Improved clarity of method call expectation exception (thanks @dantleech)
+  * Add ability to specify which argument is returned in willReturnArgument (thanks @coderbyheart)
+  * Add more information to MethodNotFound exceptions (thanks @ciaranmcnulty)
+  * Support for mocking classes with methods that return references (thanks @edsonmedina)
+  * Improved object comparison (thanks @whatthejeff)
+  * Adopted '^' in composer dependencies (thanks @GrahamCampbell)
+  * Fixed non-typehinted arguments being treated as optional (thanks @whatthejeff)
+  * Magic methods are now filtered for keywords (thanks @seagoj)
+  * More readable errors for failure when expecting single calls (thanks dantleech)
+
 1.3.1 / 2014-11-17
 ==================
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
   * Adopted '^' in composer dependencies (thanks @GrahamCampbell)
   * Fixed non-typehinted arguments being treated as optional (thanks @whatthejeff)
   * Magic methods are now filtered for keywords (thanks @seagoj)
-  * More readable errors for failure when expecting single calls (thanks dantleech)
+  * More readable errors for failure when expecting single calls (thanks @dantleech)
 
 1.3.1 / 2014-11-17
 ==================

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3.x-dev"
+            "dev-master": "1.4.x-dev"
         }
     }
 }


### PR DESCRIPTION
IMO this constitutes a minor release but YMMV

This is a subtle hint that phpspec would benefit from a newly tagged prophecy version ;-)