### PR TITLE
[Typo][Documentation]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,5 +17,5 @@ Make sure that you don't break anything with your changes by running:
 
 ```bash
 $> composer install --dev --prefer-dist
-$> vendor/bin/phpspec
+$> vendor/bin/phpspec run
 ```


### PR DESCRIPTION
Minor typo in the *CONTRIBUTING.md*, phpspec command was missing the **run** 'argument'.