### PR TITLE
Updated README.md to show StringContainsToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ That's why Prophecy comes bundled with a bunch of other tokens:
 - `CallbackToken` or `Argument::that(callback)` - checks that the argument matches a custom callback
 - `AnyValueToken` or `Argument::any()` - matches any argument
 - `AnyValuesToken` or `Argument::cetera()` - matches any arguments to the rest of the signature
+- `StringContainsToken` or `Argument::containingString($value)` - checks that the argument contains a specific string value
 
 And you can add even more by implementing `TokenInterface` with your own custom classes.
 


### PR DESCRIPTION
I just used this, and saw that it wasn't in the readme, thought that others would benefit from the clarity.