### PR TITLE
Return self promise

### DIFF
--- a/spec/Prophecy/Promise/ReturnSelfPromiseSpec.php
+++ b/spec/Prophecy/Promise/ReturnSelfPromiseSpec.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace spec\Prophecy\Promise;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ReturnSelfPromiseSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Prophecy\Promise\ReturnSelfPromise');
+    }
+
+    function it_is_a_promise()
+    {
+        $this->shouldBeAnInstanceOf('Prophecy\Promise\PromiseInterface');
+    }
+
+    /**
+     * @param \Prophecy\Prophecy\ObjectProphecy $object
+     * @param \Prophecy\Prophecy\MethodProphecy $method
+     */
+    function it_should_return_object_prophecy_used($object, $method)
+    {
+        $this->execute(array(), $object, $method)->shouldReturn($object);
+    }
+}

--- a/spec/Prophecy/Prophecy/MethodProphecySpec.php
+++ b/spec/Prophecy/Prophecy/MethodProphecySpec.php
@@ -94,6 +94,14 @@ class MethodProphecySpec extends ObjectBehavior
         $this->getPromise()->shouldBeAnInstanceOf('Prophecy\Promise\ReturnPromise');
     }
 
+    function it_adds_ReturnSelfPromise_during_willReturnSelf_call($objectProphecy)
+    {
+        $objectProphecy->addMethodProphecy($this)->willReturn(null);
+
+        $this->willReturnSelf();
+        $this->getPromise()->shouldBeAnInstanceOf('Prophecy\Promise\ReturnSelfPromise');
+    }
+
     function it_adds_ThrowPromise_during_willThrow_call($objectProphecy)
     {
         $objectProphecy->addMethodProphecy($this)->willReturn(null);

--- a/src/Prophecy/Promise/ReturnSelfPromise.php
+++ b/src/Prophecy/Promise/ReturnSelfPromise.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Prophecy\Promise;
+
+use Prophecy\Prophecy\ObjectProphecy;
+use Prophecy\Prophecy\MethodProphecy;
+
+/**
+ * Return self promise.
+ *
+ * @author Baptiste Clavié <clavie.b@gmail.com>
+ */
+class ReturnSelfPromise implements PromiseInterface
+{
+    /**
+     * Returns the object prophecy revealed
+     *
+     * @param array          $args
+     * @param ObjectProphecy $object
+     * @param MethodProphecy $method
+     *
+     * @return ObjectProphecy
+     */
+    public function execute(array $args, ObjectProphecy $object, MethodProphecy $method)
+    {
+        return $object;
+    }
+}
+

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -166,6 +166,18 @@ class MethodProphecy
     }
 
     /**
+     * Sets return self promise to the prophecy.
+     *
+     * @see Prophecy\Promise\ReturnSelfPromise
+     *
+     * @return $this
+     */
+    public function willReturnSelf()
+    {
+        return $this->will(new Promise\ReturnSelfPromise());
+    }
+
+    /**
      * Sets return argument promise to the prophecy.
      *
      * @param int $index The zero-indexed number of the argument to return


### PR DESCRIPTION
Sometimes, some chains are made on an object we would like to mock. Currently, there is no way AFAIK to be able to return the revealed object when calling one of its method.

With this patch, it should be able to do so. I am not too sure about what I did for the spec of `ReturnSelfPromise`, as I never did any phpspec before...