### PR TITLE
Add a Lazy Reveal return promise

### DIFF
--- a/spec/Prophecy/Promise/LazyRevealReturnPromiseSpec.php
+++ b/spec/Prophecy/Promise/LazyRevealReturnPromiseSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace spec\Prophecy\Promise;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class LazyRevealReturnPromiseSpec extends ObjectBehavior
+{
+    function let(ObjectProphecy $prophecy)
+    {
+        $this->beConstructedWith($prophecy);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Prophecy\Promise\LazyRevealReturnPromise');
+    }
+
+    function it_is_promise()
+    {
+        $this->shouldBeAnInstanceOf('Prophecy\Promise\PromiseInterface');
+    }
+
+    /**
+     * @param \Prophecy\Prophecy\ObjectProphecy $object
+     * @param \Prophecy\Prophecy\MethodProphecy $method
+     */
+    function it_always_returns_revealed_prophecy($object, $method, ObjectProphecy $prophecy)
+    {
+        $prophecy->reveal()->willReturn((object) array());
+
+        $this->execute(array(), $object, $method)->shouldBeAnInstanceOf('stdClass');
+    }
+}

--- a/src/Prophecy/Promise/LazyRevealReturnPromise.php
+++ b/src/Prophecy/Promise/LazyRevealReturnPromise.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Prophecy\Promise;
+
+use Prophecy\Prophecy\ObjectProphecy;
+use Prophecy\Prophecy\MethodProphecy;
+
+/**
+ * Lazy Return promise.
+ *
+ * This promise will reveal the object only when executed
+ *
+ * @author Baptiste Clavié <clavie.b@gmail.com>
+ */
+class LazyRevealReturnPromise implements PromiseInterface
+{
+    private $prophecy;
+
+    /** Initializes promise. */
+    public function __construct(ObjectProphecy $prophecy)
+    {
+        $this->prophecy = $prophecy;
+    }
+
+    /**
+     * Returns the revealed prophecy
+     *
+     * @param array          $args
+     * @param ObjectProphecy $object
+     * @param MethodProphecy $method
+     *
+     * @return object
+     */
+    public function execute(array $args, ObjectProphecy $object, MethodProphecy $method)
+    {
+        return $this->prophecy->reveal();
+    }
+}


### PR DESCRIPTION
This allows a mock call on a method to return a mocked object, and to reveal it at the latest time possible, instead of having to reveal it at the method declaration.

```php
<?php
// ... uses, class init, ... etc

$mock = $this->prophesize();
$mock2 = $this->prophesize();

$mock2->getMock()->will(new Promise\LazyRevealReturnPromise($mock));
// instead of
$mock2->getMock()->willReturn($mock->reveal());
```

I was not sure if I should add or not a helper in the `MethodProphecy`, as this is kind of specific (and how to name it : `willLazilyReturns()` ? `willLazilyRevealsAndReturn()` ?