### PR TITLE
Exceptions in argument CallbackToken

### DIFF
--- a/src/Prophecy/Argument/Token/CallbackToken.php
+++ b/src/Prophecy/Argument/Token/CallbackToken.php
@@ -50,7 +50,13 @@ class CallbackToken implements TokenInterface
      */
     public function scoreArgument($argument)
     {
-        return call_user_func($this->callback, $argument) ? 7 : false;
+        try {
+            if(call_user_func($this->callback, $argument)) {
+                return 7;
+            }
+        } catch (\Exception $e) {}
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Hi

This patch allows to throw exceptions in callbacks passed to `Prophecy\Argument\Token\CallbackToken`.

Example.

Let's say I have class:
```php
class Foo
{
    function f($arg)
    {
    }
}
```
And to test argument `$arg` passed to `Foo::f` on consecutive calls I would do something like this:
```php
class FooTest extends \PHPUnit_Framework_TestCase
{
    public function test_1()
    {
        $foo = $this->prophesize('Foo');

        $foo->f(Argument::that(function($arg) {
            return is_int($arg) &&
                $arg > 10 &&
                $arg < 15
            ;
        }))->shouldBeCalledTimes(1);
        $foo->f(Argument::that(function($arg) {
            return is_int($arg) &&
                $arg > 69 &&
                $arg < 96
            ;
        }))->shouldBeCalledTimes(1);

        $double = $foo->reveal();

        $double->f(12);
        $double->f(70);
    }
}
```

However, as for me it's more handy to use phpunit assertions inside callbacks:
```php
class FooTest extends \PHPUnit_Framework_TestCase
{
    public function test_2()
    {
        $foo = $this->prophesize('Foo');

        $foo->f(Argument::that(function($arg) {
            $this->assertInternalType('int', $arg);
            $this->assertGreaterThan(10, $arg);
            $this->assertLessThan(15, $arg);

            return true;
        }))->shouldBeCalledTimes(1);

        $foo->f(Argument::that(function($arg) {
            $this->assertInternalType('int', $arg);
            $this->assertGreaterThan(69, $arg);
            $this->assertLessThan(96, $arg);

            return true;
        }))->shouldBeCalledTimes(1);

        $double = $foo->reveal();

        $double->f(12);
        $double->f(70);
    }
}
```

But this time I'm getting: `Failed asserting that 12 is greater than 69.`

The patch fixes such issue / adds feature and doesn't seem to add BC break. Not sure if any tests required for this.
