### PR TITLE
Add support for scalar parameter types and return types

### DIFF
--- a/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
@@ -32,6 +32,8 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method1->returnsReference()->willReturn(false);
         $method1->isStatic()->willReturn(true);
         $method1->getArguments()->willReturn(array($argument11, $argument12));
+        $method1->hasReturnType()->willReturn(true);
+        $method1->getReturnType()->willReturn('string');
         $method1->getCode()->willReturn('return $this->name;');
 
         $method2->getName()->willReturn('getEmail');
@@ -39,6 +41,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method2->returnsReference()->willReturn(false);
         $method2->isStatic()->willReturn(false);
         $method2->getArguments()->willReturn(array($argument21));
+        $method2->hasReturnType()->willReturn(false);
         $method2->getCode()->willReturn('return $this->email;');
 
         $method3->getName()->willReturn('getRefValue');
@@ -46,6 +49,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method3->returnsReference()->willReturn(true);
         $method3->isStatic()->willReturn(false);
         $method3->getArguments()->willReturn(array($argument31));
+        $method3->hasReturnType()->willReturn(false);
         $method3->getCode()->willReturn('return $this->refValue;');
 
         $argument11->getName()->willReturn('fullname');
@@ -78,7 +82,7 @@ class CustomClass extends \RuntimeException implements \Prophecy\Doubler\Generat
 public $name;
 private $email;
 
-public static function getName(array $fullname = NULL, \ReflectionClass $class) {
+public static function getName(array $fullname = NULL, \ReflectionClass $class): string {
 return $this->name;
 }
 protected  function getEmail( $default = 'ever.zet@gmail.com') {
@@ -113,6 +117,7 @@ PHP;
         $method->getVisibility()->willReturn('public');
         $method->isStatic()->willReturn(false);
         $method->getArguments()->willReturn(array($argument));
+        $method->hasReturnType()->willReturn(false);
         $method->returnsReference()->willReturn(false);
         $method->getCode()->willReturn('return $this->name;');
 

--- a/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
+++ b/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
@@ -120,4 +120,19 @@ class MethodNodeSpec extends ObjectBehavior
 
         $this->getArguments()->shouldReturn(array($argument1, $argument2));
     }
+
+    function it_does_not_have_return_type_by_default()
+    {
+        $this->hasReturnType()->shouldReturn(false);
+    }
+
+    function it_setReturnType_sets_return_type()
+    {
+        $returnType = 'string';
+
+        $this->setReturnType($returnType);
+
+        $this->hasReturnType()->shouldReturn(true);
+        $this->getReturnType()->shouldReturn($returnType);
+    }
 }

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -54,12 +54,13 @@ class ClassCodeGenerator
 
     private function generateMethod(Node\MethodNode $method)
     {
-        $php = sprintf("%s %s function %s%s(%s) {\n",
+        $php = sprintf("%s %s function %s%s(%s)%s {\n",
             $method->getVisibility(),
             $method->isStatic() ? 'static' : '',
             $method->returnsReference() ? '&':'',
             $method->getName(),
-            implode(', ', $this->generateArguments($method->getArguments()))
+            implode(', ', $this->generateArguments($method->getArguments())),
+            $method->hasReturnType() ? sprintf(': %s', $method->getReturnType()) : ''
         );
         $php .= $method->getCode()."\n";
 

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -191,7 +191,7 @@ class ClassMirror
         }
 
         if (version_compare(PHP_VERSION, '7.0', '>=') && true === $parameter->hasType()) {
-            return $parameter->getType();
+            return (string) $parameter->getType();
         }
 
         return null;

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -141,6 +141,10 @@ class ClassMirror
             $node->setReturnsReference();
         }
 
+        if (version_compare(PHP_VERSION, '7.0', '>=') && true === $method->hasReturnType()) {
+            $node->setReturnType((string) $method->getReturnType());
+        }
+
         if (is_array($params = $method->getParameters()) && count($params)) {
             foreach ($params as $param) {
                 $this->reflectArgumentToNode($param, $node);

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -186,6 +186,10 @@ class ClassMirror
             return 'callable';
         }
 
+        if (version_compare(PHP_VERSION, '7.0', '>=') && true === $parameter->hasType()) {
+            return $parameter->getType();
+        }
+
         return null;
     }
 

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -126,6 +126,19 @@ class MethodNode
                 $this->returnType = $type;
                 break;
 
+            case 'double':
+            case 'real':
+                $this->returnType = 'float';
+                break;
+
+            case 'boolean':
+                $this->returnType = 'bool';
+                break;
+
+            case 'integer':
+                $this->returnType = 'int';
+                break;
+
             default:
                 $this->returnType = '\\' . ltrim($type, '\\');
         }

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -25,6 +25,7 @@ class MethodNode
     private $visibility = 'public';
     private $static = false;
     private $returnsReference = false;
+    private $returnType;
 
     /**
      * @var ArgumentNode[]
@@ -98,6 +99,41 @@ class MethodNode
     public function getArguments()
     {
         return $this->arguments;
+    }
+
+    public function hasReturnType()
+    {
+        return null !== $this->returnType;
+    }
+
+    /**
+     * @param string $type
+     */
+    public function setReturnType($type = null)
+    {
+        switch ($type) {
+            case null:
+            case '':
+                $this->returnType = null;
+                break;
+
+            case 'string';
+            case 'float':
+            case 'int':
+            case 'bool':
+            case 'array':
+            case 'callable':
+                $this->returnType = $type;
+                break;
+
+            default:
+                $this->returnType = '\\' . ltrim($type, '\\');
+        }
+    }
+
+    public function getReturnType()
+    {
+        return $this->returnType;
     }
 
     /**

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -112,7 +112,6 @@ class MethodNode
     public function setReturnType($type = null)
     {
         switch ($type) {
-            case null:
             case '':
                 $this->returnType = null;
                 break;

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -12,6 +12,7 @@
 namespace Prophecy\Prophecy;
 
 use Prophecy\Argument;
+use Prophecy\Prophet;
 use Prophecy\Promise;
 use Prophecy\Prediction;
 use Prophecy\Exception\Doubler\MethodNotFoundException;
@@ -66,6 +67,33 @@ class MethodProphecy
 
         if (null !== $arguments) {
             $this->withArguments($arguments);
+        }
+
+        if (version_compare(PHP_VERSION, '7.0', '>=') && true === $reflectedMethod->hasReturnType()) {
+            $type = (string) $reflectedMethod->getReturnType();
+            $this->will(function () use ($type) {
+                switch ($type) {
+                    case 'string': return '';
+                    case 'float':  return 0.0;
+                    case 'int':    return 0;
+                    case 'bool':   return false;
+                    case 'array':  return array();
+
+                    case 'callable':
+                    case 'Closure':
+                        return function () {};
+
+                    case 'Traversable':
+                    case 'Generator':
+                        // Remove eval() when minimum version >=5.5
+                        $generator = eval('return function () { yield; };');
+                        return $generator();
+
+                    default:
+                        $prophet = new Prophet;
+                        return $prophet->prophesize($type)->reveal();
+                }
+            });
         }
     }
 


### PR DESCRIPTION
This PR adds support for PHP 7 scalar parameter types and return types while maintaining backward compatibility with older PHP versions.

When a method prophecy is created for a method with a return type, a `CallbackPromise` is automatically added to the method prophecy that will return an appropriate type. The user can override this promise, but it prevents a method call from throwing `TypeError` if a return promise is not specified.

I'm using this library as part of PHPUnit. With this patch I was able to successfully test PHP 7 code that was otherwise failing due to: 1) revealed mocks not implementing an interface because of missing parameter or return types; or 2) methods returning `null` instead of the declared return type, resulting in a `TypeError` being thrown.