### PR TITLE
Added missing sprintf for an exception message in ReturnArgumentPromise.php

### DIFF
--- a/src/Prophecy/Promise/ReturnArgumentPromise.php
+++ b/src/Prophecy/Promise/ReturnArgumentPromise.php
@@ -37,10 +37,10 @@ class ReturnArgumentPromise implements PromiseInterface
     public function __construct($index = 0)
     {
         if (!is_int($index) || $index < 0) {
-            throw new InvalidArgumentException(
+            throw new InvalidArgumentException(sprintf(
                 'Zero-based index expected as argument to ReturnArgumentPromise, but got %s.',
-                $index
-            );
+                 gettype($index)
+            ));
         }
         $this->index = $index;
     }


### PR DESCRIPTION
If $index is for example an Object, what happend to me once during a test, fatal error is raised. Second parameter is a $code which should be an integer.
Also, from the Exception message construction (%s), it can be assumed that that's what an author wanted to do.