### PR TITLE
Don't call debug_backtrace when isn't strictly required

### DIFF
--- a/src/Prophecy/Call/CallCenter.php
+++ b/src/Prophecy/Call/CallCenter.php
@@ -54,19 +54,19 @@ class CallCenter
      */
     public function makeCall(ObjectProphecy $prophecy, $methodName, array $arguments)
     {
-        $backtrace = debug_backtrace();
-
         $file = $line = null;
-        if (isset($backtrace[2]) && isset($backtrace[2]['file'])) {
-            $file = $backtrace[2]['file'];
-            $line = $backtrace[2]['line'];
-        }
-
         // If no method prophecies defined, then it's a dummy, so we'll just return null
         if ('__destruct' === $methodName || 0 == count($prophecy->getMethodProphecies())) {
             $this->recordedCalls[] = new Call($methodName, $arguments, null, null, $file, $line);
 
             return null;
+        }
+        
+        $backtrace = debug_backtrace();
+        
+        if (isset($backtrace[2]) && isset($backtrace[2]['file'])) {
+            $file = $backtrace[2]['file'];
+            $line = $backtrace[2]['line'];
         }
 
         // There are method prophecies, so it's a fake/stub. Searching prophecy for this call


### PR DESCRIPTION
the makeCall is asking for the debug_backtrace() even when it's a dummy and dummies doesn't have file/line.

it also causes segmentation faults some times, when prophecy tries to call the debug_backtrace on a false object which is being destructed (and the garbage collector hasn't destructed it yet)

```
   20.4270   33866304                                                 -> Double\XXXX\P363->__destruct() /XXXX/vendor/phpspec/phpspec/src/PhpSpec/Wrapper/Subject/Caller.php:287
   20.4271   33866336                                                   -> Double\XXXX\P363->getProphecy() /XXXX/vendor/phpspec/prophecy/src/Prophecy/Doubler/Generator/ClassCreator.php(49) : eval()'d code:29
   20.4271   33866432                                                   -> func_get_args() /XXXX/vendor/phpspec/prophecy/src/Prophecy/Doubler/Generator/ClassCreator.php(49) : eval()'d code:29
   20.4271   33866520                                                   -> Prophecy\Prophecy\ObjectProphecy->makeProphecyMethodCall() /XXXX/vendor/phpspec/prophecy/src/Prophecy/Doubler/Generator/ClassCreator.php(49) : eval()'d code:29
   20.4271   33866520                                                     -> PhpSpec\Wrapper\Unwrapper->reveal() /XXXX/vendor/phpspec/prophecy/src/Prophecy/Prophecy/ObjectProphecy.php:188
   20.4271   33866520                                                       -> PhpSpec\Wrapper\Unwrapper->unwrapOne() /XXXX/vendor/phpspec/phpspec/src/PhpSpec/Wrapper/Unwrapper.php:68
   20.4271   33866568                                                         -> is_array() /XXXX/vendor/phpspec/phpspec/src/PhpSpec/Wrapper/Unwrapper.php:42
   20.4271   33867048                                                         -> array_map() /XXXX/vendor/phpspec/phpspec/src/PhpSpec/Wrapper/Unwrapper.php:43
   20.4271   33866656                                                     -> Prophecy\Call\CallCenter->makeCall() /XXXX/vendor/phpspec/prophecy/src/Prophecy/Prophecy/ObjectProphecy.php:189
   20.4272   33866704                                                       -> debug_backtrace() /XXXX/vendor/phpspec/prophecy/src/Prophecy/Call/CallCenter.php:57
```

```
Program received signal SIGSEGV, Segmentation fault.
0x00000001003bc1b0 in debug_backtrace_get_args ()
```