### PR TITLE
Fix #91: Variadic Resubmission

### DIFF
--- a/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
@@ -54,20 +54,23 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
 
         $argument11->getName()->willReturn('fullname');
         $argument11->getTypeHint()->willReturn('array');
-        $argument11->isOptional()->willReturn(true);
+        $argument11->hasDefault()->willReturn(true);
         $argument11->getDefault()->willReturn(null);
         $argument11->isPassedByReference()->willReturn(false);
+        $argument11->isVariadic()->willReturn(false);
 
         $argument12->getName()->willReturn('class');
         $argument12->getTypeHint()->willReturn('ReflectionClass');
-        $argument12->isOptional()->willReturn(false);
+        $argument12->hasDefault()->willReturn(false);
         $argument12->isPassedByReference()->willReturn(false);
+        $argument12->isVariadic()->willReturn(false);
 
         $argument21->getName()->willReturn('default');
         $argument21->getTypeHint()->willReturn(null);
-        $argument21->isOptional()->willReturn(true);
+        $argument21->hasDefault()->willReturn(true);
         $argument21->getDefault()->willReturn('ever.zet@gmail.com');
         $argument21->isPassedByReference()->willReturn(false);
+        $argument21->isVariadic()->willReturn(false);
 
         $argument31->getName()->willReturn('refValue');
         $argument31->getTypeHint()->willReturn(null);
@@ -101,6 +104,102 @@ PHP;
 
     /**
      * @param \Prophecy\Doubler\Generator\Node\ClassNode    $class
+     * @param \Prophecy\Doubler\Generator\Node\MethodNode   $method1
+     * @param \Prophecy\Doubler\Generator\Node\MethodNode   $method2
+     * @param \Prophecy\Doubler\Generator\Node\MethodNode   $method3
+     * @param \Prophecy\Doubler\Generator\Node\MethodNode   $method4
+     * @param \Prophecy\Doubler\Generator\Node\ArgumentNode $argument1
+     * @param \Prophecy\Doubler\Generator\Node\ArgumentNode $argument2
+     * @param \Prophecy\Doubler\Generator\Node\ArgumentNode $argument3
+     * @param \Prophecy\Doubler\Generator\Node\ArgumentNode $argument4
+     */
+    function it_generates_proper_php_code_for_variadics(
+        $class, $method1, $method2, $method3, $method4, $argument1, $argument2,
+        $argument3, $argument4
+    )
+    {
+        $class->getParentClass()->willReturn('stdClass');
+        $class->getInterfaces()->willReturn(array('Prophecy\Doubler\Generator\MirroredInterface'));
+        $class->getProperties()->willReturn(array());
+        $class->getMethods()->willReturn(array(
+            $method1, $method2, $method3, $method4
+        ));
+
+        $method1->getName()->willReturn('variadic');
+        $method1->getVisibility()->willReturn('public');
+        $method1->isStatic()->willReturn(false);
+        $method1->getArguments()->willReturn(array($argument1));
+        $method1->getCode()->willReturn('');
+
+        $method2->getName()->willReturn('variadicByRef');
+        $method2->getVisibility()->willReturn('public');
+        $method2->isStatic()->willReturn(false);
+        $method2->getArguments()->willReturn(array($argument2));
+        $method2->getCode()->willReturn('');
+
+        $method3->getName()->willReturn('variadicWithType');
+        $method3->getVisibility()->willReturn('public');
+        $method3->isStatic()->willReturn(false);
+        $method3->getArguments()->willReturn(array($argument3));
+        $method3->getCode()->willReturn('');
+
+        $method4->getName()->willReturn('variadicWithTypeByRef');
+        $method4->getVisibility()->willReturn('public');
+        $method4->isStatic()->willReturn(false);
+        $method4->getArguments()->willReturn(array($argument4));
+        $method4->getCode()->willReturn('');
+
+        $argument1->getName()->willReturn('args');
+        $argument1->getTypeHint()->willReturn(null);
+        $argument1->hasDefault()->willReturn(false);
+        $argument1->isPassedByReference()->willReturn(false);
+        $argument1->isVariadic()->willReturn(true);
+
+        $argument2->getName()->willReturn('args');
+        $argument2->getTypeHint()->willReturn(null);
+        $argument2->hasDefault()->willReturn(false);
+        $argument2->isPassedByReference()->willReturn(true);
+        $argument2->isVariadic()->willReturn(true);
+
+        $argument3->getName()->willReturn('args');
+        $argument3->getTypeHint()->willReturn('\ReflectionClass');
+        $argument3->hasDefault()->willReturn(false);
+        $argument3->isPassedByReference()->willReturn(false);
+        $argument3->isVariadic()->willReturn(true);
+
+        $argument4->getName()->willReturn('args');
+        $argument4->getTypeHint()->willReturn('\ReflectionClass');
+        $argument4->hasDefault()->willReturn(false);
+        $argument4->isPassedByReference()->willReturn(true);
+        $argument4->isVariadic()->willReturn(true);
+
+        $code = $this->generate('CustomClass', $class);
+        $expected = <<<'PHP'
+namespace  {
+class CustomClass extends \stdClass implements \Prophecy\Doubler\Generator\MirroredInterface {
+
+public  function variadic( ...$args) {
+
+}
+public  function variadicByRef( &...$args) {
+
+}
+public  function variadicWithType(\\ReflectionClass ...$args) {
+
+}
+public  function variadicWithTypeByRef(\\ReflectionClass &...$args) {
+
+}
+
+}
+}
+PHP;
+        $expected = strtr($expected, array("\r\n" => "\n", "\r" => "\n"));
+        $code->shouldBe($expected);
+    }
+
+    /**
+     * @param \Prophecy\Doubler\Generator\Node\ClassNode    $class
      * @param \Prophecy\Doubler\Generator\Node\MethodNode   $method
      * @param \Prophecy\Doubler\Generator\Node\ArgumentNode $argument
      */
@@ -123,9 +222,10 @@ PHP;
 
         $argument->getName()->willReturn('fullname');
         $argument->getTypeHint()->willReturn('array');
-        $argument->isOptional()->willReturn(true);
+        $argument->hasDefault()->willReturn(true);
         $argument->getDefault()->willReturn(null);
         $argument->isPassedByReference()->willReturn(true);
+        $argument->isVariadic()->willReturn(false);
 
         $code = $this->generate('CustomClass', $class);
         $expected =<<<'PHP'

--- a/spec/Prophecy/Doubler/Generator/ClassMirrorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassMirrorSpec.php
@@ -101,6 +101,9 @@ class ClassMirrorSpec extends ObjectBehavior
         $parameter->getDefaultValue()->willReturn(null);
         $parameter->isPassedByReference()->willReturn(false);
         $parameter->getClass()->willReturn($class);
+        if (PHP_VERSION_ID >= 50600) {
+            $parameter->isVariadic()->willReturn(false);
+        }
 
         $classNode = $this->reflect($class, array());
 
@@ -270,9 +273,10 @@ class ClassMirrorSpec extends ObjectBehavior
      * @param ReflectionParameter $param2
      * @param ReflectionClass     $typeHint
      * @param ReflectionParameter $param3
+     * @param ReflectionParameter $param4
      */
     function it_properly_reads_methods_arguments_with_types(
-        $class, $method, $param1, $param2, $typeHint, $param3
+        $class, $method, $param1, $param2, $typeHint, $param3, $param4
     )
     {
         $class->getName()->willReturn('Custom\ClassName');
@@ -286,7 +290,9 @@ class ClassMirrorSpec extends ObjectBehavior
         $method->isProtected()->willReturn(true);
         $method->isStatic()->willReturn(false);
         $method->returnsReference()->willReturn(false);
-        $method->getParameters()->willReturn(array($param1, $param2, $param3));
+        $method->getParameters()->willReturn(array(
+            $param1, $param2, $param3, $param4
+        ));
 
         if (version_compare(PHP_VERSION, '7.0', '>=')) {
             $method->hasReturnType()->willReturn(false);
@@ -320,6 +326,22 @@ class ClassMirrorSpec extends ObjectBehavior
         $param3->isPassedByReference()->willReturn(false);
         $param3->allowsNull()->willReturn(true);
 
+        $param4->getName()->willReturn('arg_4');
+        $param4->isArray()->willReturn(false);
+        $param4->getClass()->willReturn($typeHint);
+        $param4->isPassedByReference()->willReturn(false);
+        $param4->allowsNull()->willReturn(true);
+
+        if (PHP_VERSION_ID >= 50600) {
+            $param1->isVariadic()->willReturn(false);
+            $param2->isVariadic()->willReturn(false);
+            $param3->isVariadic()->willReturn(false);
+            $param4->isVariadic()->willReturn(true);
+        } else {
+            $param4->isOptional()->willReturn(true);
+            $param4->isDefaultValueAvailable()->willReturn(false);
+        }
+
         $classNode   = $this->reflect($class, array());
         $methodNodes = $classNode->getMethods();
         $argNodes    = $methodNodes['methodWithArgs']->getArguments();
@@ -340,6 +362,15 @@ class ClassMirrorSpec extends ObjectBehavior
             $argNodes[2]->getDefault()->shouldReturn(null);
         } else {
             $argNodes[2]->isOptional()->shouldReturn(false);
+        }
+
+        $argNodes[3]->getName()->shouldReturn('arg_4');
+        $argNodes[3]->getTypeHint()->shouldReturn('ArrayAccess');
+        if (PHP_VERSION_ID >= 50600) {
+            $argNodes[3]->isVariadic()->shouldReturn(true);
+        } else {
+            $argNodes[3]->isOptional()->shouldReturn(true);
+            $argNodes[3]->getDefault()->shouldReturn(null);
         }
     }
 
@@ -380,6 +411,10 @@ class ClassMirrorSpec extends ObjectBehavior
             $param1->hasType()->willReturn(false);
         }
 
+        if (version_compare(PHP_VERSION, '5.6', '>=')) {
+            $param1->isVariadic()->willReturn(false);
+        }
+
         $param1->isDefaultValueAvailable()->willReturn(false);
         $param1->isOptional()->willReturn(false);
         $param1->isPassedByReference()->willReturn(false);
@@ -400,10 +435,11 @@ class ClassMirrorSpec extends ObjectBehavior
      * @param ReflectionMethod    $method
      * @param ReflectionParameter $param1
      * @param ReflectionParameter $param2
+     * @param ReflectionParameter $param3
      * @param ReflectionClass     $typeHint
      */
     function it_marks_passed_by_reference_args_as_passed_by_reference(
-        $class, $method, $param1, $param2, $typeHint
+        $class, $method, $param1, $param2, $param3, $typeHint
     )
     {
         $class->getName()->willReturn('Custom\ClassName');
@@ -417,7 +453,7 @@ class ClassMirrorSpec extends ObjectBehavior
         $method->isProtected()->willReturn(false);
         $method->isStatic()->willReturn(false);
         $method->returnsReference()->willReturn(false);
-        $method->getParameters()->willReturn(array($param1, $param2));
+        $method->getParameters()->willReturn(array($param1, $param2, $param3));
 
         if (version_compare(PHP_VERSION, '7.0', '>=')) {
             $method->hasReturnType()->willReturn(false);
@@ -429,6 +465,9 @@ class ClassMirrorSpec extends ObjectBehavior
             $param1->isCallable()->willReturn(false);
         }
         $param1->getClass()->willReturn(null);
+        if (PHP_VERSION_ID >= 50600) {
+            $param1->isVariadic()->willReturn(false);
+        }
         $param1->isDefaultValueAvailable()->willReturn(false);
         $param1->isOptional()->willReturn(true);
         $param1->isPassedByReference()->willReturn(true);
@@ -445,6 +484,9 @@ class ClassMirrorSpec extends ObjectBehavior
         $param2->getName()->willReturn('arg2');
         $param2->isArray()->willReturn(false);
         $param2->getClass()->willReturn($typeHint);
+        if (PHP_VERSION_ID >= 50600) {
+            $param2->isVariadic()->willReturn(false);
+        }
         $param2->isDefaultValueAvailable()->willReturn(false);
         $param2->isOptional()->willReturn(false);
         $param2->isPassedByReference()->willReturn(false);
@@ -456,12 +498,25 @@ class ClassMirrorSpec extends ObjectBehavior
         $param2->allowsNull()->willReturn(false);
         $typeHint->getName()->willReturn('ArrayAccess');
 
+        $param3->getName()->willReturn('arg2');
+        $param3->isArray()->willReturn(false);
+        $param3->getClass()->willReturn($typeHint);
+        if (PHP_VERSION_ID >= 50600) {
+            $param3->isVariadic()->willReturn(true);
+        } else {
+            $param3->isOptional()->willReturn(true);
+            $param3->isDefaultValueAvailable()->willReturn(false);
+        }
+        $param3->isPassedByReference()->willReturn(true);
+        $param3->allowsNull()->willReturn(true);
+
         $classNode   = $this->reflect($class, array());
         $methodNodes = $classNode->getMethods();
         $argNodes    = $methodNodes['methodWithArgs']->getArguments();
 
         $argNodes[0]->isPassedByReference()->shouldReturn(true);
         $argNodes[1]->isPassedByReference()->shouldReturn(false);
+        $argNodes[2]->isPassedByReference()->shouldReturn(true);
     }
 
     /**

--- a/spec/Prophecy/Doubler/Generator/Node/ArgumentNodeSpec.php
+++ b/spec/Prophecy/Doubler/Generator/Node/ArgumentNodeSpec.php
@@ -22,6 +22,36 @@ class ArgumentNodeSpec extends ObjectBehavior
         $this->shouldBePassedByReference();
     }
 
+    function it_is_not_variadic_by_default()
+    {
+        $this->shouldNotBeVariadic();
+    }
+
+    function it_is_variadic_if_marked()
+    {
+        $this->setAsVariadic();
+        $this->shouldBeVariadic();
+    }
+
+    function it_does_not_have_default_by_default()
+    {
+        $this->shouldNotHaveDefault();
+    }
+
+    function it_does_not_have_default_if_variadic()
+    {
+        $this->setDefault(null);
+        $this->setAsVariadic();
+        $this->shouldNotHaveDefault();
+    }
+
+    function it_does_have_default_if_not_variadic()
+    {
+        $this->setDefault(null);
+        $this->setAsVariadic(false);
+        $this->hasDefault()->shouldReturn(true);
+    }
+
     function it_has_name_with_which_it_was_been_constructed()
     {
         $this->getName()->shouldReturn('name');

--- a/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
+++ b/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
@@ -69,13 +69,16 @@ class MethodNodeSpec extends ObjectBehavior
         $argument1->getName()->willReturn('objectName');
         $argument2->getName()->willReturn('default');
 
+        $argument1->isVariadic()->willReturn(false);
+        $argument2->isVariadic()->willReturn(true);
+
         $this->addArgument($argument1);
         $this->addArgument($argument2);
 
         $this->useParentCode();
 
         $this->getCode()->shouldReturn(
-            'return parent::getTitle($objectName, $default);'
+            'return parent::getTitle($objectName, ...$default);'
         );
     }
 

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -160,21 +160,43 @@ class ClassMirror
         $name = $parameter->getName() == '...' ? '__dot_dot_dot__' : $parameter->getName();
         $node = new Node\ArgumentNode($name);
 
-        $typeHint = $this->getTypeHint($parameter);
-        $node->setTypeHint($typeHint);
+        $node->setTypeHint($this->getTypeHint($parameter));
 
-        if (true === $parameter->isDefaultValueAvailable()) {
-            $node->setDefault($parameter->getDefaultValue());
-        } elseif (true === $parameter->isOptional()
-              || (true === $parameter->allowsNull() && $typeHint)) {
-            $node->setDefault(null);
+        if ($this->isVariadic($parameter)) {
+            $node->setAsVariadic();
         }
 
-        if (true === $parameter->isPassedByReference()) {
+        if ($this->hasDefaultValue($parameter)) {
+            $node->setDefault($this->getDefaultValue($parameter));
+        }
+
+        if ($parameter->isPassedByReference()) {
             $node->setAsPassedByReference();
         }
 
         $methodNode->addArgument($node);
+    }
+
+    private function hasDefaultValue(ReflectionParameter $parameter)
+    {
+        if ($this->isVariadic($parameter)) {
+            return false;
+        }
+
+        if ($parameter->isDefaultValueAvailable()) {
+            return true;
+        }
+
+        return $parameter->isOptional() || $this->isNullable($parameter);
+    }
+
+    private function getDefaultValue(ReflectionParameter $parameter)
+    {
+        if (!$parameter->isDefaultValueAvailable()) {
+            return null;
+        }
+
+        return $parameter->getDefaultValue();
     }
 
     private function getTypeHint(ReflectionParameter $parameter)
@@ -196,6 +218,16 @@ class ClassMirror
         }
 
         return null;
+    }
+
+    private function isVariadic(ReflectionParameter $parameter)
+    {
+        return PHP_VERSION_ID >= 50600 && $parameter->isVariadic();
+    }
+
+    private function isNullable(ReflectionParameter $parameter)
+    {
+        return $parameter->allowsNull() && null !== $this->getTypeHint($parameter);
     }
 
     private function getParameterClassName(ReflectionParameter $parameter)

--- a/src/Prophecy/Doubler/Generator/Node/ArgumentNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/ArgumentNode.php
@@ -23,6 +23,7 @@ class ArgumentNode
     private $default;
     private $optional    = false;
     private $byReference = false;
+    private $isVariadic  = false;
 
     /**
      * @param string $name
@@ -45,6 +46,11 @@ class ArgumentNode
     public function setTypeHint($typeHint = null)
     {
         $this->typeHint = $typeHint;
+    }
+
+    public function hasDefault()
+    {
+        return $this->isOptional() && !$this->isVariadic();
     }
 
     public function getDefault()
@@ -71,5 +77,15 @@ class ArgumentNode
     public function isPassedByReference()
     {
         return $this->byReference;
+    }
+
+    public function setAsVariadic($isVariadic = true)
+    {
+        $this->isVariadic = $isVariadic;
+    }
+
+    public function isVariadic()
+    {
+        return $this->isVariadic;
     }
 }

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -170,8 +170,19 @@ class MethodNode
     {
         $this->code = sprintf(
             'return parent::%s(%s);', $this->getName(), implode(', ',
-                array_map(function (ArgumentNode $arg) { return '$'.$arg->getName(); }, $this->arguments)
+                array_map(array($this, 'generateArgument'), $this->arguments)
             )
         );
+    }
+
+    private function generateArgument(ArgumentNode $arg)
+    {
+        $argument = '$'.$arg->getName();
+
+        if ($arg->isVariadic()) {
+            $argument = '...'.$argument;
+        }
+
+        return $argument;
     }
 }


### PR DESCRIPTION
Following up from #143. I'm a newbie to phpSpec, just would really like variadic's supported. Let me know what needs to be done to get this in.

There are three failures in the test suite, all with this message:
```
- it generates proper php code for specific ClassNode
- it generates proper php code for variadics
- it overrides properly methods with args passed by reference

      method call:
        - isOptional()
      on Double\Prophecy\Doubler\Generator\Node\ArgumentNode\P221 was not expected, expected calls were:
        - getName()
        - getTypeHint()
        - hasDefault()
        - getDefault()
        - isPassedByReference()
        - isVariadic()
```

Should this be "isVariadic()" rather than "isOptional()"?