### PR TITLE
Exclude 'args' in the generated backtrace

### DIFF
--- a/src/Prophecy/Call/CallCenter.php
+++ b/src/Prophecy/Call/CallCenter.php
@@ -54,7 +54,17 @@ class CallCenter
      */
     public function makeCall(ObjectProphecy $prophecy, $methodName, array $arguments)
     {
-        $backtrace = debug_backtrace();
+        // For efficiency exclude 'args' from the generated backtrace
+        if (PHP_VERSION_ID >= 50400) {
+            // Limit backtrace to last 3 calls as we don't use the rest
+            // Limit argument was introduced in PHP 5.4.0
+            $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+        } elseif (defined('DEBUG_BACKTRACE_IGNORE_ARGS')) {
+            // DEBUG_BACKTRACE_IGNORE_ARGS was introduced in PHP 5.3.6
+            $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        } else {
+            $backtrace = debug_backtrace();
+        }
 
         $file = $line = null;
         if (isset($backtrace[2]) && isset($backtrace[2]['file'])) {


### PR DESCRIPTION
This removes 'args' element from generated backtraces. If arguments are objects it will result in great performance benefit.

See [PHP: debug_backtrace - Manual](http://php.net/manual/en/function.debug-backtrace.php)

People with PHP version less than 5.3.6 will not be able to get any benefit from this change.

This is also a possible fix to #229
It fixed the random segmentation faults we were having in our PHPUnit tests.

gdb backtrace of the segmentation fault:
```
#0  debug_backtrace_get_args (curpos=<value optimized out>)
    at /usr/src/debug/php-5.5.30/Zend/zend_builtin_functions.c:2029
```