### PR TITLE
Fix code generation for scalar parameters

### DIFF
--- a/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
@@ -76,7 +76,9 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $argument31->isPassedByReference()->willReturn(false);
 
         $code = $this->generate('CustomClass', $class);
-        $expected = <<<'PHP'
+
+        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+            $expected = <<<'PHP'
 namespace  {
 class CustomClass extends \RuntimeException implements \Prophecy\Doubler\Generator\MirroredInterface, \ArrayAccess, \ArrayIterator {
 public $name;
@@ -95,6 +97,27 @@ return $this->refValue;
 }
 }
 PHP;
+        } else {
+            $expected = <<<'PHP'
+namespace  {
+class CustomClass extends \RuntimeException implements \Prophecy\Doubler\Generator\MirroredInterface, \ArrayAccess, \ArrayIterator {
+public $name;
+private $email;
+
+public static function getName(array $fullname = NULL, \ReflectionClass $class) {
+return $this->name;
+}
+protected  function getEmail(\string $default = 'ever.zet@gmail.com') {
+return $this->email;
+}
+public  function &getRefValue( $refValue) {
+return $this->refValue;
+}
+
+}
+}
+PHP;
+        }
         $expected = strtr($expected, array("\r\n" => "\n", "\r" => "\n"));
         $code->shouldBe($expected);
     }

--- a/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
@@ -64,7 +64,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $argument12->isPassedByReference()->willReturn(false);
 
         $argument21->getName()->willReturn('default');
-        $argument21->getTypeHint()->willReturn(null);
+        $argument21->getTypeHint()->willReturn('string');
         $argument21->isOptional()->willReturn(true);
         $argument21->getDefault()->willReturn('ever.zet@gmail.com');
         $argument21->isPassedByReference()->willReturn(false);
@@ -85,7 +85,7 @@ private $email;
 public static function getName(array $fullname = NULL, \ReflectionClass $class): string {
 return $this->name;
 }
-protected  function getEmail( $default = 'ever.zet@gmail.com') {
+protected  function getEmail(string $default = 'ever.zet@gmail.com') {
 return $this->email;
 }
 public  function &getRefValue( $refValue) {

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -73,10 +73,18 @@ class ClassCodeGenerator
             $php = '';
 
             if ($hint = $argument->getTypeHint()) {
-                if ('array' === $hint || 'callable' === $hint) {
-                    $php .= $hint;
-                } else {
-                    $php .= '\\'.$hint;
+                switch ($hint) {
+                    case 'array':
+                    case 'callable':
+                    case 'string':
+                    case 'int':
+                    case 'float':
+                    case 'bool':
+                        $php .= $hint;
+                        break;
+
+                    default:
+                        $php .= '\\'.$hint;
                 }
             }
 

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -60,7 +60,9 @@ class ClassCodeGenerator
             $method->returnsReference() ? '&':'',
             $method->getName(),
             implode(', ', $this->generateArguments($method->getArguments())),
-            $method->hasReturnType() ? sprintf(': %s', $method->getReturnType()) : ''
+            version_compare(PHP_VERSION, '7.0', '>=') && $method->hasReturnType()
+                ? sprintf(': %s', $method->getReturnType())
+                : ''
         );
         $php .= $method->getCode()."\n";
 
@@ -76,12 +78,18 @@ class ClassCodeGenerator
                 switch ($hint) {
                     case 'array':
                     case 'callable':
+                        $php .= $hint;
+                        break;
+
                     case 'string':
                     case 'int':
                     case 'float':
                     case 'bool':
-                        $php .= $hint;
-                        break;
+                        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+                            $php .= $hint;
+                            break;
+                        }
+                        // Fall-through to default case for PHP 5.x
 
                     default:
                         $php .= '\\'.$hint;


### PR DESCRIPTION
The latest builds of PHP 7 forbid a `\` preceding scalar types, causing a fatal error. This PR fixes the code generation of parameters with scalar type declarations.