### PR TITLE
Approximate value

### DIFF
--- a/spec/Prophecy/Argument/Token/ApproximateValueTokenSpec.php
+++ b/spec/Prophecy/Argument/Token/ApproximateValueTokenSpec.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace spec\Prophecy\Argument\Token;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ApproximateValueTokenSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(10.12345678, 4);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Prophecy\Argument\Token\ApproximateValueToken');
+    }
+
+    function it_implements_TokenInterface()
+    {
+        $this->shouldBeAnInstanceOf('Prophecy\Argument\Token\TokenInterface');
+    }
+
+    function it_is_not_last()
+    {
+        $this->shouldNotBeLast();
+    }
+
+    function it_scores_10_if_rounded_argument_matches_rounded_value()
+    {
+        $this->scoreArgument(10.12345)->shouldReturn(10);
+    }
+
+    function it_does_not_score_if_rounded_argument_does_not_match_rounded_value()
+    {
+        $this->scoreArgument(10.1234)->shouldReturn(false);
+    }
+
+    function it_uses_a_default_precision_of_zero()
+    {
+        $this->beConstructedWith(10.7);
+        $this->scoreArgument(11.4)->shouldReturn(10);
+    }
+
+    function it_does_not_score_if_rounded_argument_is_not_numeric()
+    {
+        $this->scoreArgument('hello')->shouldReturn(false);
+    }
+
+    function it_has_simple_string_representation()
+    {
+        $this->__toString()->shouldBe('≅10.1235');
+    }
+}

--- a/spec/Prophecy/ArgumentSpec.php
+++ b/spec/Prophecy/ArgumentSpec.php
@@ -98,4 +98,10 @@ class ArgumentSpec extends ObjectBehavior
         $token = $this->containingString('string');
         $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\StringContainsToken');
     }
+
+    function it_has_a_shortcut_for_approximate_token()
+    {
+        $token = $this->approximate(10);
+        $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\ApproximateValueToken');
+    }
 }

--- a/src/Prophecy/Argument.php
+++ b/src/Prophecy/Argument.php
@@ -195,4 +195,18 @@ class Argument
     {
         return new Token\IdenticalValueToken($value);
     }
+
+    /**
+     * Check that argument is same value when rounding to the
+     * given precision.
+     *
+     * @param float $value
+     * @param float $precision
+     *
+     * @return Token\ApproximateValueToken
+     */
+    public static function approximate($value, $precision = 0)
+    {
+        return new Token\ApproximateValueToken($value, $precision);
+    }
 }

--- a/src/Prophecy/Argument/Token/ApproximateValueToken.php
+++ b/src/Prophecy/Argument/Token/ApproximateValueToken.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Prophecy\Argument\Token;
+
+/**
+ * Approximate value token
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class ApproximateValueToken implements TokenInterface
+{
+    private $value;
+    private $precision;
+
+    public function __construct($value, $precision = 0)
+    {
+        $this->value = $value;
+        $this->precision = $precision;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function scoreArgument($argument)
+    {
+        return round($argument, $this->precision) === round($this->value, $this->precision) ? 10 : false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isLast()
+    {
+        return false;
+    }
+
+    /**
+     * Returns string representation for token.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return sprintf('≅%s', round($this->value, $this->precision));
+    }
+}


### PR DESCRIPTION
This value adds an ApproximateValueToken.

The approximate value rounds both the given and argument value to the given precision and compares them, returning 10 in case of a match.

This would seem to be useful in the case of expecting floating point numbers.