### PR TITLE
Patched \SplFileObject constructor while using \SplFileInfo::openDir()

### DIFF
--- a/spec/Prophecy/Doubler/ClassPatch/SplFileInfoPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/SplFileInfoPatchSpec.php
@@ -88,4 +88,20 @@ class SplFileInfoPatchSpec extends ObjectBehavior
         $this->apply($node);
     }
 
+    /**
+     * @param \Prophecy\Doubler\Generator\Node\ClassNode  $node
+     * @param \Prophecy\Doubler\Generator\Node\MethodNode $method
+     */
+    function it_should_supply_a_file_for_a_spl_file_object($node, $method)
+    {
+        $node->hasMethod('__construct')->willReturn(true);
+        $node->getMethod('__construct')->willReturn($method);
+        $node->getParentClass()->willReturn('SplFileObject');
+
+        $method->setCode(Argument::that(function($value) {
+            return strpos($value, '.php') !== false;
+        }))->shouldBeCalled();
+
+        $this->apply($node);
+    }
 }

--- a/src/Prophecy/Doubler/ClassPatch/SplFileInfoPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/SplFileInfoPatch.php
@@ -56,6 +56,13 @@ class SplFileInfoPatch implements ClassPatchInterface
 
         if ($this->nodeIsDirectoryIterator($node)) {
             $constructor->setCode('return parent::__construct("' . __DIR__ . '");');
+
+            return;
+        }
+
+        if ($this->nodeIsSplFileObject($node)) {
+            $constructor->setCode('return parent::__construct("' . __FILE__ .'");');
+
             return;
         }
 
@@ -79,7 +86,20 @@ class SplFileInfoPatch implements ClassPatchInterface
     private function nodeIsDirectoryIterator(ClassNode $node)
     {
         $parent = $node->getParentClass();
+
         return 'DirectoryIterator' === $parent
             || is_subclass_of($parent, 'DirectoryIterator');
+    }
+
+    /**
+     * @param ClassNode $node
+     * @return boolean
+     */
+    private function nodeIsSplFileObject(ClassNode $node)
+    {
+        $parent = $node->getParentClass();
+
+        return 'SplFileObject' === $parent
+            || is_subclass_of($parent, 'SplFileObject');
     }
 }


### PR DESCRIPTION
Fixed the following usecase:
```php
function it_reads_file_contents_based_on_spl_file_info(
    \SplFileInfo $fileInfo,
    \SplFileObject $fileObject
) {
    $fileInfo->openFile(Argument::cetera())->willReturn($fileObject);

    $fileObject->getSize()->willReturn(42);
    $fileObject->fread(42)->willReturn('File contents');

    $this->readFileContentsBasedOnSplFileInfo($fileInfo);
}
```