### PR TITLE
Fixed missing sprintf in InvalidArgumentException __construct call

### DIFF
--- a/src/Prophecy/Promise/ReturnArgumentPromise.php
+++ b/src/Prophecy/Promise/ReturnArgumentPromise.php
@@ -37,10 +37,10 @@ class ReturnArgumentPromise implements PromiseInterface
     public function __construct($index = 0)
     {
         if (!is_int($index) || $index < 0) {
-            throw new InvalidArgumentException(
+            throw new InvalidArgumentException(sprintf(
                 'Zero-based index expected as argument to ReturnArgumentPromise, but got %s.',
                 $index
-            );
+            ));
         }
         $this->index = $index;
     }


### PR DESCRIPTION
Having this fatal error ``PHP Fatal error:  Wrong parameters for Exception([string $exception [, long $code [, Exception $previous = NULL]]])``, I guess this exception is missing a ``sprintf``.