### PR TITLE
PhpDoc for interfaces should be used too

### DIFF
--- a/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
@@ -46,6 +46,19 @@ class MagicCallPatchSpec extends ObjectBehavior
         $this->apply($node);
     }
 
+    /**
+     * @param \Prophecy\Doubler\Generator\Node\ClassNode $node
+     */
+    function it_discovers_api_using_phpdoc_from_interface($node)
+    {
+        $node->getParentClass()->willReturn('spec\Prophecy\Doubler\ClassPatch\MagicalApiImplemented');
+
+        $node->addMethod(new MethodNode('implementedMethod'))->shouldBeCalled();
+
+        $this->apply($node);
+    }
+
+
     function it_has_50_priority()
     {
         $this->getPriority()->shouldReturn(50);
@@ -71,6 +84,21 @@ class MagicalApi
  * @method void definedMethod()
  */
 class MagicalApiExtended extends MagicalApi
+{
+
+}
+
+/**
+ */
+class MagicalApiImplemented implements MagicalApiInterface
+{
+
+}
+
+/**
+ * @method void implementedMethod()
+ */
+interface MagicalApiInterface
 {
 
 }

--- a/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
@@ -48,6 +48,12 @@ class MagicCallPatch implements ClassPatchInterface
 
         $tagList = $phpdoc->getTagsByName('method');
 
+        $interfaces = $reflectionClass->getInterfaces();
+        foreach($interfaces as $interface) {
+            $phpdoc = new DocBlock($interface);
+            $tagList = array_merge($tagList, $phpdoc->getTagsByName('method'));
+        }
+
         foreach($tagList as $tag) {
             $methodName = $tag->getMethodName();
 


### PR DESCRIPTION
look at this code:

https://github.com/nrk/predis/blob/master/src/ClientInterface.php

When you want to test code with Predis/Client you can't do it because of method is not defined error.
This pull request closes it,