### PR TITLE
add support for 'self' and 'parent' return type

### DIFF
--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -143,7 +143,17 @@ class ClassMirror
         }
 
         if (version_compare(PHP_VERSION, '7.0', '>=') && true === $method->hasReturnType()) {
-            $node->setReturnType((string) $method->getReturnType());
+            $returnType = (string) $method->getReturnType();
+            $returnTypeLower = strtolower($returnType);
+
+            if ('self' === $returnTypeLower) {
+                $returnType = $method->getDeclaringClass()->getName();
+            }
+            if ('parent' === $returnTypeLower) {
+                $returnType = $method->getDeclaringClass()->getParentClass()->getName();
+            }
+
+            $node->setReturnType($returnType);
         }
 
         if (is_array($params = $method->getParameters()) && count($params)) {


### PR DESCRIPTION
When a php7 return type is `self`, like so:

```
class Foo {
  public function setBar(Bar $bar) : self
  {
      ...
      return $this;
  }
}
```
Extending `Foo::setBar` like so
```
class Baz extends Foo {
  public function setBar(Bar $bar) : self
  {
      ...
  }
}
```
will result in
```
Compile Error: Declaration of Baz::setBar(Bar $bar): Baz must be compatible with Foo::setBar(Bar $bar): Foo
```
So the extending class must respect the return type:
```
class Baz extends Foo {
  public function setBar(Bar $bar) : Foo
  {
      ...
  }
}
```
