### PR TITLE
Ignore empty methods from phpdoc to avoid syntax erros in generated code

### DIFF
--- a/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
@@ -49,6 +49,18 @@ class MagicCallPatchSpec extends ObjectBehavior
     /**
      * @param \Prophecy\Doubler\Generator\Node\ClassNode $node
      */
+    function it_ignores_empty_methods_from_phpdoc($node)
+    {
+        $node->getParentClass()->willReturn('spec\Prophecy\Doubler\ClassPatch\MagicalApiInvalidMethodDefinition');
+
+        $node->addMethod(new MethodNode(''))->shouldNotBeCalled();
+
+        $this->apply($node);
+    }
+
+    /**
+     * @param \Prophecy\Doubler\Generator\Node\ClassNode $node
+     */
     function it_discovers_api_using_phpdoc_from_interface($node)
     {
         $node->getParentClass()->willReturn('spec\Prophecy\Doubler\ClassPatch\MagicalApiImplemented');
@@ -77,6 +89,15 @@ class MagicalApi
     {
 
     }
+}
+
+/**
+ * @method void invalidMethodDefinition
+ * @method void
+ * @method
+ */
+class MagicalApiInvalidMethodDefinition
+{
 }
 
 /**

--- a/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
@@ -57,6 +57,10 @@ class MagicCallPatch implements ClassPatchInterface
         foreach($tagList as $tag) {
             $methodName = $tag->getMethodName();
 
+            if (empty($methodName)) {
+                continue;
+            }
+
             if (!$reflectionClass->hasMethod($methodName)) {
                 $methodNode = new MethodNode($tag->getMethodName());
                 $methodNode->setStatic($tag->isStatic());


### PR DESCRIPTION
When the methods are described incorrectly in phpdoc `ClassCodeGenerator` creates incorrect code with a syntax error:

```
....
public  function () {
return $this->getProphecy()->makeProphecyMethodCall(__FUNCTION__, func_get_args());
}
...
```
`PHP Parse error:  syntax error, unexpected '(', expecting identifier (T_STRING)`