### PR TITLE
Allow Returning by reference

### DIFF
--- a/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
+++ b/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
@@ -88,13 +88,6 @@ class MethodNodeSpec extends ObjectBehavior
         $this->getCode()->shouldReturn('echo "code";');
     }
 
-    function its_reference_returning_methods_will_generate_exceptions()
-    {
-        $this->setCode('echo "code";');
-        $this->setReturnsReference();
-        $this->getCode()->shouldReturn("throw new \Prophecy\Exception\Doubler\ReturnByReferenceException('Returning by reference not supported', get_class(\$this), 'getTitle');");
-    }
-
     function its_setCode_provided_with_null_cleans_method_body()
     {
         $this->setCode(null);

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -158,11 +158,6 @@ class MethodNode
 
     public function getCode()
     {
-        if ($this->returnsReference)
-        {
-            return "throw new \Prophecy\Exception\Doubler\ReturnByReferenceException('Returning by reference not supported', get_class(\$this), '{$this->name}');";
-        }
-
         return (string) $this->code;
     }
 


### PR DESCRIPTION
I'm building mocks for an old version of ADODB database abstraction library, where the main $db->Execute() returns a reference to the result set. Without this code, my mocks works ok, so I don't know what is the reason why returning by reference is not allowed?

If there is a case where not allowing it is useful, maybe there could be a configurable parameter for that. I vote for allowing it by default.