### PR TITLE
Compatibility with phpDocumentor Reflection Dockbloc 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
   fast_finish: true
   include:
     - php: '7.0'
-      env: PHPDOCUMENTOR_REFLECTION_DOCBLOCK="~2.0"
+      env: PHPDOCUMENTOR_REFLECTION_DOCBLOCK="^2.0"
 
 before_script:
   - if [ -n "$PHPDOCUMENTOR_REFLECTION_DOCBLOCK" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,16 @@ branches:
     - /^feature\/.*$/
     - /^optimization\/.*$/
 
-before_script: travis_retry composer install --no-interaction
+matrix:
+  fast_finish: true
+  include:
+    - php: '7.0'
+      env: PHPDOCUMENTOR_REFLECTION_DOCBLOCK="~2.0"
+
+before_script:
+  - if [ -n "$PHPDOCUMENTOR_REFLECTION_DOCBLOCK" ]; then
+      composer require "phpdocumentor/reflection-docblock:${PHPDOCUMENTOR_REFLECTION_DOCBLOCK}" --no-update;
+    fi;
+  - travis_retry composer update --no-interaction
 
 script: vendor/bin/phpspec run -fpretty -v

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php":                               "^5.3|^7.0",
-        "phpdocumentor/reflection-docblock": "~2.0",
+        "phpdocumentor/reflection-docblock": "~3.0",
         "sebastian/comparator":              "~1.1",
         "doctrine/instantiator":             "^1.0.2",
         "sebastian/recursion-context":       "~1.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php":                               "^5.3|^7.0",
-        "phpdocumentor/reflection-docblock": "~3.0",
+        "phpdocumentor/reflection-docblock": "~2.0|~3.0",
         "sebastian/comparator":              "~1.1",
         "doctrine/instantiator":             "^1.0.2",
         "sebastian/recursion-context":       "~1.0"

--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,17 @@
             "email":     "marcello.duarte@gmail.com"
         }
     ],
+
     "require": {
         "php":                               "^5.3|^7.0",
-        "phpdocumentor/reflection-docblock": "~2.0|~3.0",
-        "sebastian/comparator":              "~1.1",
+        "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+        "sebastian/comparator":              "^1.1",
         "doctrine/instantiator":             "^1.0.2",
-        "sebastian/recursion-context":       "~1.0"
+        "sebastian/recursion-context":       "^1.0"
     },
 
     "require-dev": {
-        "phpspec/phpspec": "~2.0"
+        "phpspec/phpspec": "^2.0"
     },
 
     "autoload": {

--- a/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
@@ -59,14 +59,11 @@ class MagicCallPatch implements ClassPatchInterface
 
         try {
             $phpdoc = $this->docBlockFactory->create($reflectionClass, $this->contextFactory->createFromReflector($reflectionClass));
+            $tagList = $phpdoc->getTagsByName('method');
         } catch (\InvalidArgumentException $e) {
             // No DocBlock
+            $tagList = array();
         }
-
-        /**
-         * @var Method[] $tagList
-         */
-        $tagList = isset($phpdoc) ? $phpdoc->getTagsByName('method') : array();
 
         $interfaces = $reflectionClass->getInterfaces();
         foreach($interfaces as $interface) {
@@ -80,6 +77,10 @@ class MagicCallPatch implements ClassPatchInterface
 
         foreach($tagList as $tag) {
             $methodName = $tag->getMethodName();
+
+            if (empty($methodName)) {
+                continue;
+            }
 
             if (!$reflectionClass->hasMethod($methodName)) {
                 $methodNode = new MethodNode($tag->getMethodName());

--- a/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
@@ -29,7 +29,7 @@ class MagicCallPatch implements ClassPatchInterface
 
     public function __construct(MethodTagRetrieverInterface $tagRetriever = null)
     {
-        $this->tagRetriever = (null === $tagRetriever) ? new ClassAndInterfaceTagRetriever() : $tagRetriever;
+        $this->tagRetriever = null === $tagRetriever ? new ClassAndInterfaceTagRetriever() : $tagRetriever;
     }
 
     /**

--- a/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
@@ -11,7 +11,10 @@
 
 namespace Prophecy\Doubler\ClassPatch;
 
-use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlock\Tags\Method;
+use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\DocBlockFactoryInterface;
+use phpDocumentor\Reflection\Types\ContextFactory;
 use Prophecy\Doubler\Generator\Node\ClassNode;
 use Prophecy\Doubler\Generator\Node\MethodNode;
 
@@ -19,9 +22,19 @@ use Prophecy\Doubler\Generator\Node\MethodNode;
  * Discover Magical API using "@method" PHPDoc format.
  *
  * @author Thomas Tourlourat <thomas@tourlourat.com>
+ * @author Kévin Dunglas <dunglas@gmail.com>
  */
 class MagicCallPatch implements ClassPatchInterface
 {
+    private $docBlockFactory;
+    private $contextFactory;
+
+    public function __construct()
+    {
+        $this->docBlockFactory = DocBlockFactory::createInstance();
+        $this->contextFactory = new ContextFactory();
+    }
+
     /**
      * Support any class
      *
@@ -44,22 +57,29 @@ class MagicCallPatch implements ClassPatchInterface
         $parentClass = $node->getParentClass();
         $reflectionClass = new \ReflectionClass($parentClass);
 
-        $phpdoc = new DocBlock($reflectionClass->getDocComment());
+        try {
+            $phpdoc = $this->docBlockFactory->create($reflectionClass, $this->contextFactory->createFromReflector($reflectionClass));
+        } catch (\InvalidArgumentException $e) {
+            // No DocBlock
+        }
 
-        $tagList = $phpdoc->getTagsByName('method');
+        /**
+         * @var Method[] $tagList
+         */
+        $tagList = isset($phpdoc) ? $phpdoc->getTagsByName('method') : array();
 
         $interfaces = $reflectionClass->getInterfaces();
         foreach($interfaces as $interface) {
-            $phpdoc = new DocBlock($interface);
-            $tagList = array_merge($tagList, $phpdoc->getTagsByName('method'));
+            try {
+                $phpdoc = $this->docBlockFactory->create($interface, $this->contextFactory->createFromReflector($interface));
+                $tagList = array_merge($tagList, $phpdoc->getTagsByName('method'));
+            } catch (\InvalidArgumentException $e) {
+                // No DocBlock
+            }
         }
 
         foreach($tagList as $tag) {
             $methodName = $tag->getMethodName();
-
-            if (empty($methodName)) {
-                continue;
-            }
 
             if (!$reflectionClass->hasMethod($methodName)) {
                 $methodNode = new MethodNode($tag->getMethodName());

--- a/src/Prophecy/PhpDocumentor/ClassAndInterfaceTagRetriever.php
+++ b/src/Prophecy/PhpDocumentor/ClassAndInterfaceTagRetriever.php
@@ -19,9 +19,6 @@ use phpDocumentor\Reflection\DocBlock\Tags\Method;
  */
 final class ClassAndInterfaceTagRetriever implements MethodTagRetrieverInterface
 {
-    /**
-     * @var MethodTagRetrieverInterface
-     */
     private $classRetriever;
 
     public function __construct(MethodTagRetrieverInterface $classRetriever = null)
@@ -32,7 +29,7 @@ final class ClassAndInterfaceTagRetriever implements MethodTagRetrieverInterface
             return;
         }
 
-        $this->classRetriever = (class_exists('phpDocumentor\Reflection\DocBlockFactory') && class_exists('phpDocumentor\Reflection\Types\ContextFactory'))
+        $this->classRetriever = class_exists('phpDocumentor\Reflection\DocBlockFactory') && class_exists('phpDocumentor\Reflection\Types\ContextFactory')
             ? new ClassTagRetriever()
             : new LegacyClassTagRetriever()
         ;
@@ -46,7 +43,7 @@ final class ClassAndInterfaceTagRetriever implements MethodTagRetrieverInterface
     public function getTagList(\ReflectionClass $reflectionClass)
     {
         return array_merge(
-            $this->getTagList($reflectionClass),
+            $this->classRetriever->getTagList($reflectionClass),
             $this->getInterfacesTagList($reflectionClass)
         );
     }
@@ -62,7 +59,7 @@ final class ClassAndInterfaceTagRetriever implements MethodTagRetrieverInterface
         $tagList = array();
 
         foreach($interfaces as $interface) {
-            $tagList = array_merge($tagList, $this->getTagList($interface));
+            $tagList = array_merge($tagList, $this->classRetriever->getTagList($interface));
         }
 
         return $tagList;

--- a/src/Prophecy/PhpDocumentor/ClassAndInterfaceTagRetriever.php
+++ b/src/Prophecy/PhpDocumentor/ClassAndInterfaceTagRetriever.php
@@ -16,6 +16,8 @@ use phpDocumentor\Reflection\DocBlock\Tags\Method;
 
 /**
  * @author Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * @internal
  */
 final class ClassAndInterfaceTagRetriever implements MethodTagRetrieverInterface
 {

--- a/src/Prophecy/PhpDocumentor/ClassAndInterfaceTagRetriever.php
+++ b/src/Prophecy/PhpDocumentor/ClassAndInterfaceTagRetriever.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Prophecy\PhpDocumentor;
+
+use phpDocumentor\Reflection\DocBlock\Tag\MethodTag as LegacyMethodTag;
+use phpDocumentor\Reflection\DocBlock\Tags\Method;
+
+/**
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+final class ClassAndInterfaceTagRetriever implements MethodTagRetrieverInterface
+{
+    /**
+     * @var MethodTagRetrieverInterface
+     */
+    private $classRetriever;
+
+    public function __construct(MethodTagRetrieverInterface $classRetriever = null)
+    {
+        if (null !== $classRetriever) {
+            $this->classRetriever = $classRetriever;
+
+            return;
+        }
+
+        $this->classRetriever = (class_exists('phpDocumentor\Reflection\DocBlockFactory') && class_exists('phpDocumentor\Reflection\Types\ContextFactory'))
+            ? new ClassTagRetriever()
+            : new LegacyClassTagRetriever()
+        ;
+    }
+
+    /**
+     * @param \ReflectionClass $reflectionClass
+     *
+     * @return LegacyMethodTag[]|Method[]
+     */
+    public function getTagList(\ReflectionClass $reflectionClass)
+    {
+        return array_merge(
+            $this->getTagList($reflectionClass),
+            $this->getInterfacesTagList($reflectionClass)
+        );
+    }
+
+    /**
+     * @param \ReflectionClass $reflectionClass
+     *
+     * @return LegacyMethodTag[]|Method[]
+     */
+    private function getInterfacesTagList(\ReflectionClass $reflectionClass)
+    {
+        $interfaces = $reflectionClass->getInterfaces();
+        $tagList = array();
+
+        foreach($interfaces as $interface) {
+            $tagList = array_merge($tagList, $this->getTagList($interface));
+        }
+
+        return $tagList;
+    }
+}

--- a/src/Prophecy/PhpDocumentor/ClassTagRetriever.php
+++ b/src/Prophecy/PhpDocumentor/ClassTagRetriever.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Prophecy\PhpDocumentor;
+
+use phpDocumentor\Reflection\DocBlock\Tags\Method;
+use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\Types\ContextFactory;
+
+/**
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+final class ClassTagRetriever implements MethodTagRetrieverInterface
+{
+    private $docBlockFactory;
+    private $contextFactory;
+
+    public function __construct()
+    {
+        $this->docBlockFactory = DocBlockFactory::createInstance();
+        $this->contextFactory = new ContextFactory();
+    }
+
+    /**
+     * @param \ReflectionClass $reflectionClass
+     *
+     * @return Method[]
+     */
+    public function getTagList(\ReflectionClass $reflectionClass)
+    {
+        try {
+            $phpdoc = $this->docBlockFactory->create(
+                $reflectionClass,
+                $this->contextFactory->createFromReflector($reflectionClass)
+            );
+
+            return $phpdoc->getTagsByName('method');
+        } catch (\InvalidArgumentException $e) {
+            return array();
+        }
+    }
+}

--- a/src/Prophecy/PhpDocumentor/ClassTagRetriever.php
+++ b/src/Prophecy/PhpDocumentor/ClassTagRetriever.php
@@ -17,6 +17,8 @@ use phpDocumentor\Reflection\Types\ContextFactory;
 
 /**
  * @author Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * @internal
  */
 final class ClassTagRetriever implements MethodTagRetrieverInterface
 {

--- a/src/Prophecy/PhpDocumentor/LegacyClassTagRetriever.php
+++ b/src/Prophecy/PhpDocumentor/LegacyClassTagRetriever.php
@@ -16,6 +16,8 @@ use phpDocumentor\Reflection\DocBlock\Tag\MethodTag as LegacyMethodTag;
 
 /**
  * @author Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * @internal
  */
 final class LegacyClassTagRetriever implements MethodTagRetrieverInterface
 {

--- a/src/Prophecy/PhpDocumentor/LegacyClassTagRetriever.php
+++ b/src/Prophecy/PhpDocumentor/LegacyClassTagRetriever.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Prophecy\PhpDocumentor;
+
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlock\Tag\MethodTag as LegacyMethodTag;
+
+/**
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+final class LegacyClassTagRetriever implements MethodTagRetrieverInterface
+{
+    /**
+     * @param \ReflectionClass $reflectionClass
+     *
+     * @return LegacyMethodTag[]
+     */
+    public function getTagList(\ReflectionClass $reflectionClass)
+    {
+        $phpdoc = new DocBlock($reflectionClass->getDocComment());
+
+        return $phpdoc->getTagsByName('method');
+    }
+}

--- a/src/Prophecy/PhpDocumentor/MethodTagRetrieverInterface.php
+++ b/src/Prophecy/PhpDocumentor/MethodTagRetrieverInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Prophecy\PhpDocumentor;
+
+use phpDocumentor\Reflection\DocBlock\Tag\MethodTag as LegacyMethodTag;
+use phpDocumentor\Reflection\DocBlock\Tags\Method;
+
+/**
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+interface MethodTagRetrieverInterface
+{
+    /**
+     * @param \ReflectionClass $reflectionClass
+     *
+     * @return LegacyMethodTag[]|Method[]
+     */
+    public function getTagList(\ReflectionClass $reflectionClass);
+}

--- a/src/Prophecy/PhpDocumentor/MethodTagRetrieverInterface.php
+++ b/src/Prophecy/PhpDocumentor/MethodTagRetrieverInterface.php
@@ -16,6 +16,8 @@ use phpDocumentor\Reflection\DocBlock\Tags\Method;
 
 /**
  * @author Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * @internal
  */
 interface MethodTagRetrieverInterface
 {


### PR DESCRIPTION
Follow up of #264. Allow to use Prophecy (and PHPUnit) with Symfony 3.1.

Test that it works with @fabiang's patch on ReflectionDocBlock merged: https://github.com/phpDocumentor/ReflectionDocBlock/pull/72

The last commit (update of  `composer.json` to use the branch of Fabian) must be removed before the merge in Prophecy.

ping @mvriel