### PR TITLE
Fix incorrect ObjectStateToken method argument order

### DIFF
--- a/src/Prophecy/Argument/Token/ObjectStateToken.php
+++ b/src/Prophecy/Argument/Token/ObjectStateToken.php
@@ -61,11 +61,11 @@ class ObjectStateToken implements TokenInterface
             $actual = call_user_func(array($argument, $this->name));
 
             $comparator = $this->comparatorFactory->getComparatorFor(
-                $actual, $this->value
+                $this->value, $actual
             );
 
             try {
-                $comparator->assertEquals($actual, $this->value);
+                $comparator->assertEquals($this->value, $actual);
                 return 8;
             } catch (ComparisonFailure $failure) {
                 return false;


### PR DESCRIPTION
this doesn't actually cause a visible misbehaviour, but is obviously still technically wrong;
since there is no functional change, no spec/test possible