### PR TITLE
Add PHP 7.1 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-php: [5.3, 5.4, 5.5, 5.6, 7.0, hhvm]
+php: [5.3, 5.4, 5.5, 5.6, 7.0, 7.1, hhvm]
 
 sudo: false
 


### PR DESCRIPTION
I did some tests with PHP 7.1 and Prophecy locally and it seems like Prophecy does not work with PHP 7.1, so I'm adding it to the build matrix to see if tests passes.