### PR TITLE
Allow \Error instances in ThrowPromise

### DIFF
--- a/spec/Prophecy/Promise/ThrowPromiseSpec.php
+++ b/spec/Prophecy/Promise/ThrowPromiseSpec.php
@@ -54,7 +54,7 @@ class ThrowPromiseSpec extends ObjectBehavior
         $this->shouldThrow($exc)->duringExecute(array(), $object, $method);
     }
 
-    function it_throws_errors(ObjectProphecy $object, MethodProphecy $method)
+    function it_throws_error_instances(ObjectProphecy $object, MethodProphecy $method)
     {
         if (!class_exists('\Error')) {
             throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
@@ -63,6 +63,38 @@ class ThrowPromiseSpec extends ObjectBehavior
         $this->beConstructedWith($exc = new \Error('Error exception'));
 
         $this->shouldThrow($exc)->duringExecute(array(), $object, $method);
+    }
+
+    function it_throws_errors_by_class_name()
+    {
+        if (!class_exists('\Error')) {
+            throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
+        }
+
+        $this->beConstructedWith('\Error');
+
+        $this->shouldNotThrow('Prophecy\Exception\InvalidArgumentException')->duringInstantiation();
+    }
+
+    function it_does_not_throw_something_that_is_not_throwable_by_class_name()
+    {
+        $this->beConstructedWith('\stdClass');
+
+        $this->shouldThrow('Prophecy\Exception\InvalidArgumentException')->duringInstantiation();
+    }
+
+    function it_does_not_throw_something_that_is_not_throwable_by_instance()
+    {
+        $this->beConstructedWith(new \stdClass());
+
+        $this->shouldThrow('Prophecy\Exception\InvalidArgumentException')->duringInstantiation();
+    }
+
+    function it_throws_an_exception_by_class_name()
+    {
+        $this->beConstructedWith('\Exception');
+
+        $this->shouldNotThrow('Prophecy\Exception\InvalidArgumentException')->duringInstantiation();
     }
 }
 

--- a/spec/Prophecy/Promise/ThrowPromiseSpec.php
+++ b/spec/Prophecy/Promise/ThrowPromiseSpec.php
@@ -2,7 +2,10 @@
 
 namespace spec\Prophecy\Promise;
 
+use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Prophecy\MethodProphecy;
+use Prophecy\Prophecy\ObjectProphecy;
 
 class ThrowPromiseSpec extends ObjectBehavior
 {
@@ -47,6 +50,17 @@ class ThrowPromiseSpec extends ObjectBehavior
     function it_throws_provided_exception($object, $method)
     {
         $this->beConstructedWith($exc = new \RuntimeException('Some exception'));
+
+        $this->shouldThrow($exc)->duringExecute(array(), $object, $method);
+    }
+
+    function it_throws_errors(ObjectProphecy $object, MethodProphecy $method)
+    {
+        if (!class_exists('\Error')) {
+            throw new SkippingException('The class Error, introduced in PHP 7, does not exist');
+        }
+
+        $this->beConstructedWith($exc = new \Error('Error exception'));
 
         $this->shouldThrow($exc)->duringExecute(array(), $object, $method);
     }

--- a/src/Prophecy/Promise/ThrowPromise.php
+++ b/src/Prophecy/Promise/ThrowPromise.php
@@ -34,7 +34,7 @@ class ThrowPromise implements PromiseInterface
     /**
      * Initializes promise.
      *
-     * @param string|\Exception $exception Exception class name or instance
+     * @param string|\Exception|\Throwable $exception Exception class name or instance
      *
      * @throws \Prophecy\Exception\InvalidArgumentException
      */

--- a/src/Prophecy/Promise/ThrowPromise.php
+++ b/src/Prophecy/Promise/ThrowPromise.php
@@ -94,6 +94,6 @@ class ThrowPromise implements PromiseInterface
      */
     private function isAValidThrowable($exception)
     {
-        return is_a($exception, 'Exception') || is_subclass_of($exception, 'Throwable');
+        return is_a($exception, 'Exception', true) || is_subclass_of($exception, 'Throwable', true);
     }
 }

--- a/src/Prophecy/Promise/ThrowPromise.php
+++ b/src/Prophecy/Promise/ThrowPromise.php
@@ -41,7 +41,7 @@ class ThrowPromise implements PromiseInterface
     public function __construct($exception)
     {
         if (is_string($exception)) {
-            if (!class_exists($exception) || $this->isNotAValidThrowable($exception)) {
+            if (!class_exists($exception) || !$this->isAValidThrowable($exception)) {
                 throw new InvalidArgumentException(sprintf(
                     'Exception / Throwable class or instance expected as argument to ThrowPromise, but got %s.',
                     $exception
@@ -87,8 +87,13 @@ class ThrowPromise implements PromiseInterface
         throw $this->exception;
     }
 
-    private function isNotAValidThrowable($exception)
+    /**
+     * @param string $exception
+     *
+     * @return bool
+     */
+    private function isAValidThrowable($exception)
     {
-        return 'Exception' !== ltrim($exception, '\\') && !is_subclass_of($exception, 'Exception') && !is_subclass_of($exception, 'Throwable');
+        return is_a($exception, 'Exception') || is_subclass_of($exception, 'Throwable');
     }
 }

--- a/src/Prophecy/Promise/ThrowPromise.php
+++ b/src/Prophecy/Promise/ThrowPromise.php
@@ -41,17 +41,15 @@ class ThrowPromise implements PromiseInterface
     public function __construct($exception)
     {
         if (is_string($exception)) {
-            if (!class_exists($exception)
-             && 'Exception' !== $exception
-             && !is_subclass_of($exception, 'Exception')) {
+            if (!class_exists($exception) || $this->isNotAValidThrowable($exception)) {
                 throw new InvalidArgumentException(sprintf(
-                    'Exception class or instance expected as argument to ThrowPromise, but got %s.',
+                    'Exception / Throwable class or instance expected as argument to ThrowPromise, but got %s.',
                     $exception
                 ));
             }
         } elseif (!$exception instanceof \Exception && !$exception instanceof \Throwable) {
             throw new InvalidArgumentException(sprintf(
-                'Exception/Error class or instance expected as argument to ThrowPromise, but got %s.',
+                'Exception / Throwable class or instance expected as argument to ThrowPromise, but got %s.',
                 is_object($exception) ? get_class($exception) : gettype($exception)
             ));
         }
@@ -87,5 +85,10 @@ class ThrowPromise implements PromiseInterface
         }
 
         throw $this->exception;
+    }
+
+    private function isNotAValidThrowable($exception)
+    {
+        return 'Exception' !== ltrim($exception, '\\') && !is_subclass_of($exception, 'Exception') && !is_subclass_of($exception, 'Throwable');
     }
 }

--- a/src/Prophecy/Promise/ThrowPromise.php
+++ b/src/Prophecy/Promise/ThrowPromise.php
@@ -49,9 +49,9 @@ class ThrowPromise implements PromiseInterface
                     $exception
                 ));
             }
-        } elseif (!$exception instanceof \Exception) {
+        } elseif (!$exception instanceof \Exception && !$exception instanceof \Throwable) {
             throw new InvalidArgumentException(sprintf(
-                'Exception class or instance expected as argument to ThrowPromise, but got %s.',
+                'Exception/Error class or instance expected as argument to ThrowPromise, but got %s.',
                 is_object($exception) ? get_class($exception) : gettype($exception)
             ));
         }


### PR DESCRIPTION
Fixes #281.

The build will fail until the corresponding PHPSpec PR (https://github.com/phpspec/phpspec/pull/1006) is merged into a stable release.
