### PR TITLE
Allow __soapCall to be mocked.

### DIFF
--- a/fixtures/SpecialMethods.php
+++ b/fixtures/SpecialMethods.php
@@ -33,4 +33,8 @@ class SpecialMethods
     {
     }
 
+    function __soapCall($function_name, array $arguments, array $options = null, $input_headers = null, array &$output_headers = null)
+    {
+    }
+
 }

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -32,6 +32,7 @@ class ClassMirror
         '__wakeup',
         '__toString',
         '__call',
+        '__soapCall',
         '__invoke'
     );
 

--- a/tests/Doubler/Generator/ClassMirrorTest.php
+++ b/tests/Doubler/Generator/ClassMirrorTest.php
@@ -17,7 +17,7 @@ class ClassMirrorTest extends \PHPUnit_Framework_TestCase
 
         $node = $mirror->reflect($class, array());
 
-        $this->assertCount(7, $node->getMethods());
+        $this->assertCount(8, $node->getMethods());
     }
 
     /**


### PR DESCRIPTION
PHP's SoapClient has a public method `__soapCall` which is basically `__call` with a special signature. This change allows this method to be mocked.