### PR TITLE
Allow \SoapClient's non-magic, magic-looking methods to be mocked.

### DIFF
--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -32,7 +32,19 @@ class ClassMirror
         '__wakeup',
         '__toString',
         '__call',
-        '__invoke'
+        '__invoke',
+        // \SoapClient's non-magic methods that look like they are magic.
+        '__doRequest',
+        '__getFunctions',
+        '__getLastRequest',
+        '__getLastRequestHeaders',
+        '__getLastResponse',
+        '__getLastResponseHeaders',
+        '__getTypes',
+        '__setCookie',
+        '__setLocation',
+        '__setSoapHeaders',
+        '__soapCall',
     );
 
     /**


### PR DESCRIPTION
I'm trying to mock `\SoapClient::__soapCall()` in my own project, which looks like a magic method, but isn't. `\Prophecy\Doubler\Generator\ClassMirror::$reflectableMethods` lists the only methods starting with one (or more) underscore that Prophecy can mock. Adding `__soapCall` there makes my mock work as expected. I added the other non-magic, magic-looking sibling methods from http://php.net/manual/en/class.soapclient.php as well.