### PR TITLE
PHP 7.1 types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 branches:
   except:
     - /^bugfix\/.*$/
+    - /^feature\/.*$/
     - /^optimization\/.*$/
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache:
 branches:
   except:
     - /^bugfix\/.*$/
-    - /^feature\/.*$/
     - /^optimization\/.*$/
 
 matrix:
@@ -26,10 +25,10 @@ matrix:
       env: PHPDOCUMENTOR_REFLECTION_DOCBLOCK="^2.0"
 
 before_script:
+  - travis_retry composer update --no-interaction
   - if [ -n "$PHPDOCUMENTOR_REFLECTION_DOCBLOCK" ]; then
       composer require "phpdocumentor/reflection-docblock:${PHPDOCUMENTOR_REFLECTION_DOCBLOCK}" --no-update;
     fi;
-  - travis_retry composer update --no-interaction
 
 script:
   - vendor/bin/phpspec run -fpretty -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ matrix:
       env: PHPDOCUMENTOR_REFLECTION_DOCBLOCK="^2.0"
 
 before_script:
-  - travis_retry composer update --no-interaction
   - if [ -n "$PHPDOCUMENTOR_REFLECTION_DOCBLOCK" ]; then
       composer require "phpdocumentor/reflection-docblock:${PHPDOCUMENTOR_REFLECTION_DOCBLOCK}" --no-update;
     fi;
+  - travis_retry composer update --no-interaction
 
 script:
   - vendor/bin/phpspec run -fpretty -v

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
 
     "require-dev": {
-        "phpspec/phpspec": "^2.0",
+        "phpspec/phpspec": "^2.0 || ^3.0",
         "phpunit/phpunit": "^4.8 || ^5.6.5"
     },
 

--- a/spec/Prophecy/Call/CallCenterSpec.php
+++ b/spec/Prophecy/Call/CallCenterSpec.php
@@ -49,14 +49,17 @@ class CallCenterSpec extends ObjectBehavior
         ArgumentsWildcard $arguments3,
         PromiseInterface $promise
     ) {
+        $method1->hasVoidReturnType()->willReturn(false);
         $method1->getMethodName()->willReturn('getName');
         $method1->getArgumentsWildcard()->willReturn($arguments1);
         $arguments1->scoreArguments(array('world', 'everything'))->willReturn(false);
 
+        $method2->hasVoidReturnType()->willReturn(false);
         $method2->getMethodName()->willReturn('setTitle');
         $method2->getArgumentsWildcard()->willReturn($arguments2);
         $arguments2->scoreArguments(array('world', 'everything'))->willReturn(false);
 
+        $method3->hasVoidReturnType()->willReturn(false);
         $method3->getMethodName()->willReturn('getName');
         $method3->getArgumentsWildcard()->willReturn($arguments3);
         $method3->getPromise()->willReturn($promise);

--- a/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
@@ -60,32 +60,6 @@ class MagicCallPatchSpec extends ObjectBehavior
         $this->apply($node);
     }
 
-    /**
-     * @param \Prophecy\Doubler\Generator\Node\ClassNode $node
-     */
-    function it_discovers_api_using_phpdoc_from_own_interfaces($node)
-    {
-        $node->getParentClass()->willReturn('stdClass');
-        $node->getInterfaces()->willReturn(array('spec\Prophecy\Doubler\ClassPatch\MagicalApiImplemented'));
-
-        $node->addMethod(new MethodNode('implementedMethod'))->shouldBeCalled();
-
-        $this->apply($node);
-    }
-
-    /**
-     * @param \Prophecy\Doubler\Generator\Node\ClassNode $node
-     */
-    function it_discovers_api_using_phpdoc_from_extended_parent_interfaces($node)
-    {
-        $node->getParentClass()->willReturn('spec\Prophecy\Doubler\ClassPatch\MagicalApiImplementedExtended');
-        $node->getInterfaces()->willReturn(array());
-
-        $node->addMethod(new MethodNode('implementedMethod'))->shouldBeCalled();
-
-        $this->apply($node);
-    }
-
     function it_has_50_priority()
     {
         $this->getPriority()->shouldReturn(50);

--- a/spec/Prophecy/Doubler/ClassPatch/ProphecySubjectPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/ProphecySubjectPatchSpec.php
@@ -55,6 +55,10 @@ class ProphecySubjectPatchSpec extends ObjectBehavior
         $method2->getName()->willReturn('method2');
         $method3->getName()->willReturn('method3');
 
+        $method1->getReturnType()->willReturn('int');
+        $method2->getReturnType()->willReturn('int');
+        $method3->getReturnType()->willReturn('void');
+
         $node->getMethods()->willReturn(array(
             'method1' => $method1,
             'method2' => $method2,
@@ -67,7 +71,7 @@ class ProphecySubjectPatchSpec extends ObjectBehavior
             ->shouldBeCalled();
         $method2->setCode('return $this->getProphecy()->makeProphecyMethodCall(__FUNCTION__, func_get_args());')
             ->shouldBeCalled();
-        $method3->setCode('return $this->getProphecy()->makeProphecyMethodCall(__FUNCTION__, func_get_args());')
+        $method3->setCode('$this->getProphecy()->makeProphecyMethodCall(__FUNCTION__, func_get_args());')
             ->shouldBeCalled();
 
         $this->apply($node);

--- a/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
@@ -35,6 +35,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method1->getArguments()->willReturn(array($argument11, $argument12));
         $method1->hasReturnType()->willReturn(true);
         $method1->getReturnType()->willReturn('string');
+        $method1->hasNullableReturnType()->willReturn(true);
         $method1->getCode()->willReturn('return $this->name;');
 
         $method2->getName()->willReturn('getEmail');
@@ -43,6 +44,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method2->isStatic()->willReturn(false);
         $method2->getArguments()->willReturn(array($argument21));
         $method2->hasReturnType()->willReturn(false);
+        $method2->hasNullableReturnType()->willReturn(true);
         $method2->getCode()->willReturn('return $this->email;');
 
         $method3->getName()->willReturn('getRefValue');
@@ -50,7 +52,9 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method3->returnsReference()->willReturn(true);
         $method3->isStatic()->willReturn(false);
         $method3->getArguments()->willReturn(array($argument31));
-        $method3->hasReturnType()->willReturn(false);
+        $method1->hasReturnType()->willReturn(true);
+        $method1->getReturnType()->willReturn('void');
+        $method3->hasNullableReturnType()->willReturn(false);
         $method3->getCode()->willReturn('return $this->refValue;');
 
         $argument11->getName()->willReturn('fullname');
@@ -58,12 +62,14 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $argument11->isOptional()->willReturn(true);
         $argument11->getDefault()->willReturn(null);
         $argument11->isPassedByReference()->willReturn(false);
+        $argument11->isNullable()->willReturn(false);
         $argument11->isVariadic()->willReturn(false);
 
         $argument12->getName()->willReturn('class');
         $argument12->getTypeHint()->willReturn('ReflectionClass');
         $argument12->isOptional()->willReturn(false);
         $argument12->isPassedByReference()->willReturn(false);
+        $argument12->isNullable()->willReturn(false);
         $argument12->isVariadic()->willReturn(false);
 
         $argument21->getName()->willReturn('default');
@@ -71,6 +77,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $argument21->isOptional()->willReturn(true);
         $argument21->getDefault()->willReturn('ever.zet@gmail.com');
         $argument21->isPassedByReference()->willReturn(false);
+        $argument21->isNullable()->willReturn(true);
         $argument21->isVariadic()->willReturn(false);
 
         $argument31->getName()->willReturn('refValue');
@@ -78,11 +85,32 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $argument31->isOptional()->willReturn(false);
         $argument31->getDefault()->willReturn();
         $argument31->isPassedByReference()->willReturn(false);
+        $argument31->isNullable()->willReturn(false);
         $argument31->isVariadic()->willReturn(false);
 
         $code = $this->generate('CustomClass', $class);
 
-        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+        if (version_compare(PHP_VERSION, '7.1', '>=')) {
+            $expected = <<<'PHP'
+namespace  {
+class CustomClass extends \RuntimeException implements \Prophecy\Doubler\Generator\MirroredInterface, \ArrayAccess, \ArrayIterator {
+public $name;
+private $email;
+
+public static function getName(array $fullname = NULL, \ReflectionClass $class): ?string {
+return $this->name;
+}
+protected  function getEmail(?string $default = 'ever.zet@gmail.com') {
+return $this->email;
+}
+public  function &getRefValue( $refValue): void {
+return $this->refValue;
+}
+
+}
+}
+PHP;
+        } elseif (version_compare(PHP_VERSION, '7.0', '>=')) {
             $expected = <<<'PHP'
 namespace  {
 class CustomClass extends \RuntimeException implements \Prophecy\Doubler\Generator\MirroredInterface, \ArrayAccess, \ArrayIterator {
@@ -182,24 +210,32 @@ PHP;
         $argument1->isOptional()->willReturn(false);
         $argument1->isPassedByReference()->willReturn(false);
         $argument1->isVariadic()->willReturn(true);
+        $argument1->isNullable()->willReturn(false);
+        $argument1->isNullable()->willReturn(false);
 
         $argument2->getName()->willReturn('args');
         $argument2->getTypeHint()->willReturn(null);
         $argument2->isOptional()->willReturn(false);
         $argument2->isPassedByReference()->willReturn(true);
         $argument2->isVariadic()->willReturn(true);
+        $argument2->isNullable()->willReturn(false);
+        $argument2->isNullable()->willReturn(false);
 
         $argument3->getName()->willReturn('args');
         $argument3->getTypeHint()->willReturn('\ReflectionClass');
         $argument3->isOptional()->willReturn(false);
         $argument3->isPassedByReference()->willReturn(false);
         $argument3->isVariadic()->willReturn(true);
+        $argument3->isNullable()->willReturn(false);
+        $argument3->isNullable()->willReturn(false);
 
         $argument4->getName()->willReturn('args');
         $argument4->getTypeHint()->willReturn('\ReflectionClass');
         $argument4->isOptional()->willReturn(false);
         $argument4->isPassedByReference()->willReturn(true);
         $argument4->isVariadic()->willReturn(true);
+        $argument4->isNullable()->willReturn(false);
+        $argument4->isNullable()->willReturn(false);
 
         $code = $this->generate('CustomClass', $class);
         $expected = <<<'PHP'
@@ -249,6 +285,7 @@ PHP;
         $argument->isOptional()->willReturn(true);
         $argument->getDefault()->willReturn(null);
         $argument->isPassedByReference()->willReturn(true);
+        $argument->isNullable()->willReturn(false);
         $argument->isVariadic()->willReturn(false);
 
         $code = $this->generate('CustomClass', $class);

--- a/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
@@ -123,7 +123,7 @@ return $this->name;
 protected  function getEmail(string $default = 'ever.zet@gmail.com') {
 return $this->email;
 }
-public  function &getRefValue( $refValue) {
+public  function &getRefValue( $refValue): void {
 return $this->refValue;
 }
 

--- a/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
@@ -52,8 +52,8 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method3->returnsReference()->willReturn(true);
         $method3->isStatic()->willReturn(false);
         $method3->getArguments()->willReturn(array($argument31));
-        $method1->hasReturnType()->willReturn(true);
-        $method1->getReturnType()->willReturn('void');
+        $method3->hasReturnType()->willReturn(true);
+        $method3->getReturnType()->willReturn('void');
         $method3->hasNullableReturnType()->willReturn(false);
         $method3->getCode()->willReturn('return $this->refValue;');
 

--- a/src/Prophecy/Doubler/ClassPatch/ProphecySubjectPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/ProphecySubjectPatch.php
@@ -50,9 +50,15 @@ class ProphecySubjectPatch implements ClassPatchInterface
                 continue;
             }
 
-            $method->setCode(
-                'return $this->getProphecy()->makeProphecyMethodCall(__FUNCTION__, func_get_args());'
-            );
+            if ('void' === $method->getReturnType()) {
+                $method->setCode(
+                    '$this->getProphecy()->makeProphecyMethodCall(__FUNCTION__, func_get_args());'
+                );
+            } else {
+                $method->setCode(
+                    'return $this->getProphecy()->makeProphecyMethodCall(__FUNCTION__, func_get_args());'
+                );
+            }
         }
 
         $prophecySetter = new MethodNode('setProphecy');

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -82,7 +82,9 @@ class ClassCodeGenerator
         return array_map(function (Node\ArgumentNode $argument) {
             $php = '';
 
-            $php .= $argument->isNullable() ? '?' : '';
+            if (version_compare(PHP_VERSION, '7.1', '>=')) {
+                $php .= $argument->isNullable() ? '?' : '';
+            }
 
             if ($hint = $argument->getTypeHint()) {
                 switch ($hint) {

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -54,15 +54,23 @@ class ClassCodeGenerator
 
     private function generateMethod(Node\MethodNode $method)
     {
+        $returnType = '';
+
+        if (version_compare(PHP_VERSION, '7.0', '>=') && $method->hasReturnType()) {
+            if (version_compare(PHP_VERSION, '7.1', '>=') && $method->hasNullableReturnType()) {
+                $returnType = sprintf(': ?%s', $method->getReturnType());
+            } else {
+                $returnType = sprintf(': %s', $method->getReturnType());
+            }
+        }
+
         $php = sprintf("%s %s function %s%s(%s)%s {\n",
             $method->getVisibility(),
             $method->isStatic() ? 'static' : '',
             $method->returnsReference() ? '&':'',
             $method->getName(),
             implode(', ', $this->generateArguments($method->getArguments())),
-            version_compare(PHP_VERSION, '7.0', '>=') && $method->hasReturnType()
-                ? sprintf(': %s', $method->getReturnType())
-                : ''
+            $returnType
         );
         $php .= $method->getCode()."\n";
 
@@ -74,11 +82,22 @@ class ClassCodeGenerator
         return array_map(function (Node\ArgumentNode $argument) {
             $php = '';
 
+            $php .= $argument->isNullable() ? '?' : '';
+
             if ($hint = $argument->getTypeHint()) {
                 switch ($hint) {
                     case 'array':
                     case 'callable':
                         $php .= $hint;
+                        break;
+
+                    case 'iterable':
+                        if (version_compare(PHP_VERSION, '7.1', '>=')) {
+                            $php .= $hint;
+                            break;
+                        }
+
+                        $php .= '\\'.$hint;
                         break;
 
                     case 'string':
@@ -96,7 +115,9 @@ class ClassCodeGenerator
                 }
             }
 
-            $php .= ' '.($argument->isPassedByReference() ? '&' : '');
+            $php .= ' ';
+
+            $php .= $argument->isPassedByReference() ? '&' : '';
 
             $php .= $argument->isVariadic() ? '...' : '';
 

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -155,6 +155,10 @@ class ClassMirror
             }
 
             $node->setReturnType($returnType);
+
+            if (version_compare(PHP_VERSION, '7.1', '>=') && true === $method->getReturnType()->allowsNull()) {
+                $node->setNullableReturnType(true);
+            }
         }
 
         if (is_array($params = $method->getParameters()) && count($params)) {

--- a/src/Prophecy/Doubler/Generator/Node/ArgumentNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/ArgumentNode.php
@@ -24,6 +24,7 @@ class ArgumentNode
     private $optional    = false;
     private $byReference = false;
     private $isVariadic  = false;
+    private $isNullable  = false;
 
     /**
      * @param string $name
@@ -87,5 +88,15 @@ class ArgumentNode
     public function isVariadic()
     {
         return $this->isVariadic;
+    }
+
+    public function isNullable()
+    {
+        return $this->isNullable;
+    }
+
+    public function setAsNullable($isNullable = true)
+    {
+        $this->isNullable = $isNullable;
     }
 }

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -26,6 +26,7 @@ class MethodNode
     private $static = false;
     private $returnsReference = false;
     private $returnType;
+    private $nullableReturnType = false;
 
     /**
      * @var ArgumentNode[]
@@ -122,6 +123,8 @@ class MethodNode
             case 'bool':
             case 'array':
             case 'callable':
+            case 'iterable':
+            case 'void':
                 $this->returnType = $type;
                 break;
 
@@ -184,5 +187,21 @@ class MethodNode
         }
 
         return $argument;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function hasNullableReturnType()
+    {
+        return $this->nullableReturnType;
+    }
+
+    /**
+     * @param boolean $nullableReturnType
+     */
+    public function setNullableReturnType($nullableReturnType = true)
+    {
+        $this->nullableReturnType = $nullableReturnType;
     }
 }

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -33,6 +33,7 @@ class MethodProphecy
     private $prediction;
     private $checkedPredictions = array();
     private $bound = false;
+    private $voidReturnType = false;
 
     /**
      * Initializes method prophecy.
@@ -71,6 +72,12 @@ class MethodProphecy
 
         if (version_compare(PHP_VERSION, '7.0', '>=') && true === $reflectedMethod->hasReturnType()) {
             $type = (string) $reflectedMethod->getReturnType();
+
+            if ('void' === $type) {
+                $this->voidReturnType = true;
+                return;
+            }
+
             $this->will(function () use ($type) {
                 switch ($type) {
                     case 'string': return '';
@@ -160,9 +167,15 @@ class MethodProphecy
      * @see Prophecy\Promise\ReturnPromise
      *
      * @return $this
+     *
+     * @throws MethodProphecyException
      */
     public function willReturn()
     {
+        if ($this->voidReturnType) {
+            throw new MethodProphecyException('This method has a void return type', $this);
+        }
+
         return $this->will(new Promise\ReturnPromise(func_get_args()));
     }
 
@@ -174,9 +187,15 @@ class MethodProphecy
      * @see Prophecy\Promise\ReturnArgumentPromise
      *
      * @return $this
+     *
+     * @throws MethodProphecyException
      */
     public function willReturnArgument($index = 0)
     {
+        if ($this->voidReturnType) {
+            throw new MethodProphecyException('This method has a void return type', $this);
+        }
+
         return $this->will(new Promise\ReturnArgumentPromise($index));
     }
 
@@ -282,7 +301,7 @@ class MethodProphecy
             ));
         }
 
-        if (null === $this->promise) {
+        if (null === $this->promise && !$this->hasVoidReturnType()) {
             $this->willReturn();
         }
 
@@ -434,5 +453,13 @@ class MethodProphecy
 
         $this->getObjectProphecy()->addMethodProphecy($this);
         $this->bound = true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasVoidReturnType()
+    {
+        return $this->voidReturnType;
     }
 }


### PR DESCRIPTION
Added support for PHP 7.1 types.

- Allowed `void` return type
- Allowed `iterable` type
- Allowed nullable arguments
- Allowed nullable return types