### PR TITLE
Discover api from PHPDoc of *all* parent classes

### DIFF
--- a/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
@@ -29,6 +29,17 @@ class MagicCallPatchSpec extends ObjectBehavior
         $this->apply($node);
     }
 
+    function it_discovers_api_using_phpdocs_of_parent_classes(ClassNode $node)
+    {
+        $node->getParentClass()->willReturn('spec\Prophecy\Doubler\ClassPatch\MagicalApiChild');
+        $node->getInterfaces()->willReturn(array());
+
+        $node->addMethod(new MethodNode('undefinedMethod'))->shouldBeCalled();
+        $node->addMethod(new MethodNode('undefinedMethodChild'))->shouldBeCalled();
+
+        $this->apply($node);
+    }
+
     function it_ignores_existing_methods(ClassNode $node)
     {
         $node->getParentClass()->willReturn('spec\Prophecy\Doubler\ClassPatch\MagicalApiExtended');
@@ -122,6 +133,13 @@ class MagicalApiInvalidMethodDefinition
 class MagicalApiExtended extends MagicalApi
 {
 
+}
+
+/**
+ * @method void undefinedMethodChild()
+ */
+class MagicalApiChild extends MagicalApi
+{
 }
 
 /**

--- a/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
@@ -54,7 +54,10 @@ class MagicCallPatch implements ClassPatchInterface
         $types = array_filter($node->getInterfaces(), function ($interface) {
             return 0 !== strpos($interface, 'Prophecy\\');
         });
-        $types[] = $node->getParentClass();
+        $parentClass = $node->getParentClass();
+        do {
+            $types[] = $parentClass;
+        } while ($parentClass = get_parent_class($parentClass));
 
         foreach ($types as $type) {
             $reflectionClass = new \ReflectionClass($type);


### PR DESCRIPTION
Example:

```
/**
 * @method void undefinedMethod()
 */
class MagicalApi
{
}

/**
 * @method void undefinedMethodChild()
 */
class MagicalApiChild extends MagicalApi
{
}
```

Should be possible mock methods defined in child and parent PHPDocs:
- `undefinedMethod`
- `undefinedMethodChild`

So:
```php
$prophesize = $this->prophesize(MagicalApiChild::class);
$prophesize->undefinedMethod()->willReturn(...);
$prophesize->undefinedMethodChild()->willReturn(...);
```

Currently is possible to mock only `undefinedMethodChild`:
```php
$prophesize = $this->prophesize(MagicalApiChild::class);
$prophesize->undefinedMethodChild()->willReturn(...);
```
and:

```php
$prophesize->undefinedMethod()->willReturn(...);
```

will throw an exception:
```
Method `Double\MagicalApiChild\P2::undefinedMethod()` is not defined.
```