### PR TITLE
Allow sebastian/comparator ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php":                               "^5.3|^7.0",
         "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-        "sebastian/comparator":              "^1.1",
+        "sebastian/comparator":              "^1.1|^2.0",
         "doctrine/instantiator":             "^1.0.2",
         "sebastian/recursion-context":       "^1.0|^2.0"
     },


### PR DESCRIPTION
sebastian/comparator ^2.0 will not break API. It just drops support for PHP 5.