### PR TITLE
Allow sebastian/recursion-context ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
         "sebastian/comparator":              "^1.1|^2.0",
         "doctrine/instantiator":             "^1.0.2",
-        "sebastian/recursion-context":       "^1.0|^2.0"
+        "sebastian/recursion-context":       "^1.0|^2.0|^3.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
sebastian/recursion-context ^3.0 will not break API. It just drops support for PHP 5.