### PR TITLE
Add PHP 7.1 Support

### DIFF
--- a/spec/Prophecy/Call/CallCenterSpec.php
+++ b/spec/Prophecy/Call/CallCenterSpec.php
@@ -49,14 +49,17 @@ class CallCenterSpec extends ObjectBehavior
         ArgumentsWildcard $arguments3,
         PromiseInterface $promise
     ) {
+        $method1->hasReturnVoid()->willReturn(false);
         $method1->getMethodName()->willReturn('getName');
         $method1->getArgumentsWildcard()->willReturn($arguments1);
         $arguments1->scoreArguments(array('world', 'everything'))->willReturn(false);
 
+        $method2->hasReturnVoid()->willReturn(false);
         $method2->getMethodName()->willReturn('setTitle');
         $method2->getArgumentsWildcard()->willReturn($arguments2);
         $arguments2->scoreArguments(array('world', 'everything'))->willReturn(false);
 
+        $method3->hasReturnVoid()->willReturn(false);
         $method3->getMethodName()->willReturn('getName');
         $method3->getArgumentsWildcard()->willReturn($arguments3);
         $method3->getPromise()->willReturn($promise);
@@ -88,15 +91,18 @@ class CallCenterSpec extends ObjectBehavior
         ArgumentsWildcard $arguments3,
         PromiseInterface $promise
     ) {
+        $method1->hasReturnVoid()->willReturn(false);
         $method1->getMethodName()->willReturn('getName');
         $method1->getArgumentsWildcard()->willReturn($arguments1);
         $arguments1->scoreArguments(array('world', 'everything'))->willReturn(50);
 
+        $method2->hasReturnVoid()->willReturn(false);
         $method2->getMethodName()->willReturn('getName');
         $method2->getArgumentsWildcard()->willReturn($arguments2);
         $method2->getPromise()->willReturn($promise);
         $arguments2->scoreArguments(array('world', 'everything'))->willReturn(300);
 
+        $method3->hasReturnVoid()->willReturn(false);
         $method3->getMethodName()->willReturn('getName');
         $method3->getArgumentsWildcard()->willReturn($arguments3);
         $arguments3->scoreArguments(array('world', 'everything'))->willReturn(200);
@@ -139,6 +145,7 @@ class CallCenterSpec extends ObjectBehavior
         MethodProphecy $method,
         ArgumentsWildcard $arguments
     ) {
+        $method->hasReturnVoid()->willReturn(false);
         $method->getMethodName()->willReturn('getName');
         $method->getArgumentsWildcard()->willReturn($arguments);
         $method->getPromise()->willReturn(null);

--- a/spec/Prophecy/Doubler/ClassPatch/ProphecySubjectPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/ProphecySubjectPatchSpec.php
@@ -55,6 +55,10 @@ class ProphecySubjectPatchSpec extends ObjectBehavior
         $method2->getName()->willReturn('method2');
         $method3->getName()->willReturn('method3');
 
+        $method1->getReturnType()->willReturn('int');
+        $method2->getReturnType()->willReturn('int');
+        $method3->getReturnType()->willReturn('void');
+
         $node->getMethods()->willReturn(array(
             'method1' => $method1,
             'method2' => $method2,
@@ -67,7 +71,7 @@ class ProphecySubjectPatchSpec extends ObjectBehavior
             ->shouldBeCalled();
         $method2->setCode('return $this->getProphecy()->makeProphecyMethodCall(__FUNCTION__, func_get_args());')
             ->shouldBeCalled();
-        $method3->setCode('return $this->getProphecy()->makeProphecyMethodCall(__FUNCTION__, func_get_args());')
+        $method3->setCode('$this->getProphecy()->makeProphecyMethodCall(__FUNCTION__, func_get_args());')
             ->shouldBeCalled();
 
         $this->apply($node);

--- a/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
@@ -16,6 +16,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         MethodNode $method1,
         MethodNode $method2,
         MethodNode $method3,
+        MethodNode $method4,
         ArgumentNode $argument11,
         ArgumentNode $argument12,
         ArgumentNode $argument21,
@@ -26,7 +27,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
             'Prophecy\Doubler\Generator\MirroredInterface', 'ArrayAccess', 'ArrayIterator'
         ));
         $class->getProperties()->willReturn(array('name' => 'public', 'email' => 'private'));
-        $class->getMethods()->willReturn(array($method1, $method2, $method3));
+        $class->getMethods()->willReturn(array($method1, $method2, $method3, $method4));
 
         $method1->getName()->willReturn('getName');
         $method1->getVisibility()->willReturn('public');
@@ -53,9 +54,19 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method3->isStatic()->willReturn(false);
         $method3->getArguments()->willReturn(array($argument31));
         $method3->hasReturnType()->willReturn(true);
-        $method3->getReturnType()->willReturn('void');
+        $method3->getReturnType()->willReturn('string');
         $method3->hasNullableReturnType()->willReturn(false);
         $method3->getCode()->willReturn('return $this->refValue;');
+
+        $method4->getName()->willReturn('doSomething');
+        $method4->getVisibility()->willReturn('public');
+        $method4->returnsReference()->willReturn(false);
+        $method4->isStatic()->willReturn(false);
+        $method4->getArguments()->willReturn(array());
+        $method4->hasReturnType()->willReturn(true);
+        $method4->getReturnType()->willReturn('void');
+        $method4->hasNullableReturnType()->willReturn(false);
+        $method4->getCode()->willReturn('return;');
 
         $argument11->getName()->willReturn('fullname');
         $argument11->getTypeHint()->willReturn('array');
@@ -103,8 +114,11 @@ return $this->name;
 protected  function getEmail(?string $default = 'ever.zet@gmail.com') {
 return $this->email;
 }
-public  function &getRefValue( $refValue): void {
+public  function &getRefValue( $refValue): string {
 return $this->refValue;
+}
+public  function doSomething(): void {
+return;
 }
 
 }
@@ -123,8 +137,11 @@ return $this->name;
 protected  function getEmail(string $default = 'ever.zet@gmail.com') {
 return $this->email;
 }
-public  function &getRefValue( $refValue) {
+public  function &getRefValue( $refValue): string {
 return $this->refValue;
+}
+public  function doSomething() {
+return;
 }
 
 }
@@ -145,6 +162,9 @@ return $this->email;
 }
 public  function &getRefValue( $refValue) {
 return $this->refValue;
+}
+public  function doSomething() {
+return;
 }
 
 }

--- a/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
@@ -35,7 +35,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method1->getArguments()->willReturn(array($argument11, $argument12));
         $method1->hasReturnType()->willReturn(true);
         $method1->getReturnType()->willReturn('string');
-        $method1->hasNullableReturnType()->willReturn(false);
+        $method1->hasNullableReturnType()->willReturn(true);
         $method1->getCode()->willReturn('return $this->name;');
 
         $method2->getName()->willReturn('getEmail');
@@ -44,6 +44,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method2->isStatic()->willReturn(false);
         $method2->getArguments()->willReturn(array($argument21));
         $method2->hasReturnType()->willReturn(false);
+        $method2->hasNullableReturnType()->willReturn(true);
         $method2->getCode()->willReturn('return $this->email;');
 
         $method3->getName()->willReturn('getRefValue');
@@ -51,7 +52,9 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method3->returnsReference()->willReturn(true);
         $method3->isStatic()->willReturn(false);
         $method3->getArguments()->willReturn(array($argument31));
-        $method3->hasReturnType()->willReturn(false);
+        $method3->hasReturnType()->willReturn(true);
+        $method3->getReturnType()->willReturn('void');
+        $method3->hasNullableReturnType()->willReturn(false);
         $method3->getCode()->willReturn('return $this->refValue;');
 
         $argument11->getName()->willReturn('fullname');
@@ -60,12 +63,14 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $argument11->getDefault()->willReturn(null);
         $argument11->isPassedByReference()->willReturn(false);
         $argument11->isVariadic()->willReturn(false);
+        $argument11->isNullable()->willReturn(false);
 
         $argument12->getName()->willReturn('class');
         $argument12->getTypeHint()->willReturn('ReflectionClass');
         $argument12->isOptional()->willReturn(false);
         $argument12->isPassedByReference()->willReturn(false);
         $argument12->isVariadic()->willReturn(false);
+        $argument12->isNullable()->willReturn(false);
 
         $argument21->getName()->willReturn('default');
         $argument21->getTypeHint()->willReturn('string');
@@ -73,6 +78,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $argument21->getDefault()->willReturn('ever.zet@gmail.com');
         $argument21->isPassedByReference()->willReturn(false);
         $argument21->isVariadic()->willReturn(false);
+        $argument21->isNullable()->willReturn(true);
 
         $argument31->getName()->willReturn('refValue');
         $argument31->getTypeHint()->willReturn(null);
@@ -80,10 +86,31 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $argument31->getDefault()->willReturn();
         $argument31->isPassedByReference()->willReturn(false);
         $argument31->isVariadic()->willReturn(false);
+        $argument31->isNullable()->willReturn(false);
 
         $code = $this->generate('CustomClass', $class);
 
-        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+        if (version_compare(PHP_VERSION, '7.1', '>=')) {
+            $expected = <<<'PHP'
+namespace  {
+class CustomClass extends \RuntimeException implements \Prophecy\Doubler\Generator\MirroredInterface, \ArrayAccess, \ArrayIterator {
+public $name;
+private $email;
+
+public static function getName(array $fullname = NULL, \ReflectionClass $class): ?string {
+return $this->name;
+}
+protected  function getEmail(?string $default = 'ever.zet@gmail.com') {
+return $this->email;
+}
+public  function &getRefValue( $refValue): void {
+return $this->refValue;
+}
+
+}
+}
+PHP;
+        } elseif (version_compare(PHP_VERSION, '7.0', '>=')) {
             $expected = <<<'PHP'
 namespace  {
 class CustomClass extends \RuntimeException implements \Prophecy\Doubler\Generator\MirroredInterface, \ArrayAccess, \ArrayIterator {
@@ -183,24 +210,28 @@ PHP;
         $argument1->isOptional()->willReturn(false);
         $argument1->isPassedByReference()->willReturn(false);
         $argument1->isVariadic()->willReturn(true);
+        $argument1->isNullable()->willReturn(false);
 
         $argument2->getName()->willReturn('args');
         $argument2->getTypeHint()->willReturn(null);
         $argument2->isOptional()->willReturn(false);
         $argument2->isPassedByReference()->willReturn(true);
         $argument2->isVariadic()->willReturn(true);
+        $argument2->isNullable()->willReturn(false);
 
         $argument3->getName()->willReturn('args');
         $argument3->getTypeHint()->willReturn('\ReflectionClass');
         $argument3->isOptional()->willReturn(false);
         $argument3->isPassedByReference()->willReturn(false);
         $argument3->isVariadic()->willReturn(true);
+        $argument3->isNullable()->willReturn(false);
 
         $argument4->getName()->willReturn('args');
         $argument4->getTypeHint()->willReturn('\ReflectionClass');
         $argument4->isOptional()->willReturn(false);
         $argument4->isPassedByReference()->willReturn(true);
         $argument4->isVariadic()->willReturn(true);
+        $argument4->isNullable()->willReturn(false);
 
         $code = $this->generate('CustomClass', $class);
         $expected = <<<'PHP'
@@ -251,6 +282,7 @@ PHP;
         $argument->getDefault()->willReturn(null);
         $argument->isPassedByReference()->willReturn(true);
         $argument->isVariadic()->willReturn(false);
+        $argument->isNullable()->willReturn(false);
 
         $code = $this->generate('CustomClass', $class);
         $expected =<<<'PHP'

--- a/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
@@ -35,6 +35,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method1->getArguments()->willReturn(array($argument11, $argument12));
         $method1->hasReturnType()->willReturn(true);
         $method1->getReturnType()->willReturn('string');
+        $method1->hasNullableReturnType()->willReturn(false);
         $method1->getCode()->willReturn('return $this->name;');
 
         $method2->getName()->willReturn('getEmail');

--- a/src/Prophecy/Call/CallCenter.php
+++ b/src/Prophecy/Call/CallCenter.php
@@ -109,7 +109,7 @@ class CallCenter
         }
 
         if ($methodProphecy->hasReturnVoid() && $returnValue !== null) {
-            throw new MethodProphecyException('This method has a void return type', $methodProphecy);
+            throw new MethodProphecyException("The method \"$methodName\" has a void return type", $methodProphecy);
         }
 
         $this->recordedCalls[] = new Call(

--- a/src/Prophecy/Call/CallCenter.php
+++ b/src/Prophecy/Call/CallCenter.php
@@ -11,6 +11,7 @@
 
 namespace Prophecy\Call;
 
+use Prophecy\Exception\Prophecy\MethodProphecyException;
 use Prophecy\Prophecy\MethodProphecy;
 use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\Argument\ArgumentsWildcard;
@@ -96,14 +97,19 @@ class CallCenter
         @usort($matches, function ($match1, $match2) { return $match2[0] - $match1[0]; });
 
         // If Highest rated method prophecy has a promise - execute it or return null instead
+        $methodProphecy = $matches[0][1];
         $returnValue = null;
         $exception   = null;
-        if ($promise = $matches[0][1]->getPromise()) {
+        if ($promise = $methodProphecy->getPromise()) {
             try {
-                $returnValue = $promise->execute($arguments, $prophecy, $matches[0][1]);
+                $returnValue = $promise->execute($arguments, $prophecy, $methodProphecy);
             } catch (\Exception $e) {
                 $exception = $e;
             }
+        }
+
+        if ($methodProphecy->hasReturnVoid() && $returnValue !== null) {
+            throw new MethodProphecyException('This method has a void return type', $methodProphecy);
         }
 
         $this->recordedCalls[] = new Call(

--- a/src/Prophecy/Call/CallCenter.php
+++ b/src/Prophecy/Call/CallCenter.php
@@ -109,7 +109,10 @@ class CallCenter
         }
 
         if ($methodProphecy->hasReturnVoid() && $returnValue !== null) {
-            throw new MethodProphecyException("The method \"$methodName\" has a void return type", $methodProphecy);
+            throw new MethodProphecyException(
+                "The method \"$methodName\" has a void return type, but the promise returned a value",
+                $methodProphecy
+            );
         }
 
         $this->recordedCalls[] = new Call(

--- a/src/Prophecy/Doubler/ClassPatch/ProphecySubjectPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/ProphecySubjectPatch.php
@@ -50,9 +50,15 @@ class ProphecySubjectPatch implements ClassPatchInterface
                 continue;
             }
 
-            $method->setCode(
-                'return $this->getProphecy()->makeProphecyMethodCall(__FUNCTION__, func_get_args());'
-            );
+            if ($method->getReturnType() === 'void') {
+                $method->setCode(
+                    '$this->getProphecy()->makeProphecyMethodCall(__FUNCTION__, func_get_args());'
+                );
+            } else {
+                $method->setCode(
+                    'return $this->getProphecy()->makeProphecyMethodCall(__FUNCTION__, func_get_args());'
+                );
+            }
         }
 
         $prophecySetter = new MethodNode('setProphecy');

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -61,7 +61,9 @@ class ClassCodeGenerator
             $method->getName(),
             implode(', ', $this->generateArguments($method->getArguments())),
             version_compare(PHP_VERSION, '7.0', '>=') && $method->hasReturnType()
-                ? sprintf(': %s', $method->getReturnType())
+                ? version_compare(PHP_VERSION, '7.1', '>=') && $method->hasNullableReturnType()
+                ? sprintf(': ?%s', $method->getReturnType())
+                : sprintf(': %s', $method->getReturnType())
                 : ''
         );
         $php .= $method->getCode()."\n";

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -60,15 +60,33 @@ class ClassCodeGenerator
             $method->returnsReference() ? '&':'',
             $method->getName(),
             implode(', ', $this->generateArguments($method->getArguments())),
-            version_compare(PHP_VERSION, '7.0', '>=') && $method->hasReturnType()
-                ? version_compare(PHP_VERSION, '7.1', '>=') && $method->hasNullableReturnType()
-                ? sprintf(': ?%s', $method->getReturnType())
-                : sprintf(': %s', $method->getReturnType())
-                : ''
+            $this->getReturnType($method)
         );
         $php .= $method->getCode()."\n";
 
         return $php.'}';
+    }
+
+    /**
+     * @return string
+     */
+    private function getReturnType(Node\MethodNode $method)
+    {
+        if (version_compare(PHP_VERSION, '7.1', '>=')) {
+            if ($method->hasReturnType()) {
+                return $method->hasNullableReturnType()
+                    ? sprintf(': ?%s', $method->getReturnType())
+                    : sprintf(': %s', $method->getReturnType());
+            }
+        }
+
+        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+            return $method->hasReturnType() && $method->getReturnType() !== 'void'
+                ? sprintf(': %s', $method->getReturnType())
+                : '';
+        }
+
+        return '';
     }
 
     private function generateArguments(array $arguments)

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -76,11 +76,24 @@ class ClassCodeGenerator
         return array_map(function (Node\ArgumentNode $argument) {
             $php = '';
 
+            if (version_compare(PHP_VERSION, '7.1', '>=')) {
+                $php .= $argument->isNullable() ? '?' : '';
+            }
+
             if ($hint = $argument->getTypeHint()) {
                 switch ($hint) {
                     case 'array':
                     case 'callable':
                         $php .= $hint;
+                        break;
+
+                    case 'iterable':
+                        if (version_compare(PHP_VERSION, '7.1', '>=')) {
+                            $php .= $hint;
+                            break;
+                        }
+
+                        $php .= '\\'.$hint;
                         break;
 
                     case 'string':

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -143,7 +143,7 @@ class ClassMirror
             $node->setReturnsReference();
         }
 
-        if (version_compare(PHP_VERSION, '7.0', '>=') && true === $method->hasReturnType()) {
+        if (version_compare(PHP_VERSION, '7.0', '>=') && $method->hasReturnType()) {
             $returnType = (string) $method->getReturnType();
             $returnTypeLower = strtolower($returnType);
 

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -155,6 +155,10 @@ class ClassMirror
             }
 
             $node->setReturnType($returnType);
+
+            if (version_compare(PHP_VERSION, '7.1', '>=') && true === $method->getReturnType()->allowsNull()) {
+                $node->setNullableReturnType(true);
+            }
         }
 
         if (is_array($params = $method->getParameters()) && count($params)) {

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -156,7 +156,7 @@ class ClassMirror
 
             $node->setReturnType($returnType);
 
-            if (version_compare(PHP_VERSION, '7.1', '>=') && true === $method->getReturnType()->allowsNull()) {
+            if (version_compare(PHP_VERSION, '7.1', '>=') && $method->getReturnType()->allowsNull()) {
                 $node->setNullableReturnType(true);
             }
         }

--- a/src/Prophecy/Doubler/Generator/Node/ArgumentNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/ArgumentNode.php
@@ -24,6 +24,7 @@ class ArgumentNode
     private $optional    = false;
     private $byReference = false;
     private $isVariadic  = false;
+    private $isNullable  = false;
 
     /**
      * @param string $name
@@ -87,5 +88,15 @@ class ArgumentNode
     public function isVariadic()
     {
         return $this->isVariadic;
+    }
+
+    public function isNullable()
+    {
+        return $this->isNullable;
+    }
+
+    public function setAsNullable($isNullable = true)
+    {
+        $this->isNullable = $isNullable;
     }
 }

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -164,10 +164,6 @@ class MethodNode
             return "throw new \Prophecy\Exception\Doubler\ReturnByReferenceException('Returning by reference not supported', get_class(\$this), '{$this->name}');";
         }
 
-        if ($this->returnType === 'void') {
-            return substr((string) $this->code, 7);
-        }
-
         return (string) $this->code;
     }
 

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -122,6 +122,7 @@ class MethodNode
             case 'bool':
             case 'array':
             case 'callable':
+            case 'void':
                 $this->returnType = $type;
                 break;
 
@@ -161,6 +162,10 @@ class MethodNode
         if ($this->returnsReference)
         {
             return "throw new \Prophecy\Exception\Doubler\ReturnByReferenceException('Returning by reference not supported', get_class(\$this), '{$this->name}');";
+        }
+
+        if ($this->returnType === 'void') {
+            return substr((string) $this->code, 7);
         }
 
         return (string) $this->code;

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -26,6 +26,7 @@ class MethodNode
     private $static = false;
     private $returnsReference = false;
     private $returnType;
+    private $nullableReturnType = false;
 
     /**
      * @var ArgumentNode[]
@@ -147,6 +148,22 @@ class MethodNode
     public function getReturnType()
     {
         return $this->returnType;
+    }
+
+    /**
+     * @param bool $bool
+     */
+    public function setNullableReturnType($bool)
+    {
+        $this->nullableReturnType = (bool) $bool;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasNullableReturnType()
+    {
+        return $this->nullableReturnType;
     }
 
     /**

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -123,6 +123,7 @@ class MethodNode
             case 'bool':
             case 'array':
             case 'callable':
+            case 'iterable':
             case 'void':
                 $this->returnType = $type;
                 break;
@@ -153,7 +154,7 @@ class MethodNode
     /**
      * @param bool $bool
      */
-    public function setNullableReturnType($bool)
+    public function setNullableReturnType($bool = true)
     {
         $this->nullableReturnType = (bool) $bool;
     }

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -441,6 +441,14 @@ class MethodProphecy
         return $this->argumentsWildcard;
     }
 
+    /**
+     * @return bool
+     */
+    public function hasReturnVoid()
+    {
+        return $this->voidReturnType;
+    }
+
     private function bindToObjectProphecy()
     {
         if ($this->bound) {

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -171,7 +171,10 @@ class MethodProphecy
     public function willReturn()
     {
         if ($this->voidReturnType) {
-            throw new MethodProphecyException("The method \"$this->methodName\" has a void return type", $this);
+            throw new MethodProphecyException(
+                "The method \"$this->methodName\" has a void return type, and so cannot return anything",
+                $this
+            );
         }
 
         return $this->will(new Promise\ReturnPromise(func_get_args()));

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -171,7 +171,7 @@ class MethodProphecy
     public function willReturn()
     {
         if ($this->voidReturnType) {
-            throw new MethodProphecyException('This method has a void return type', $this);
+            throw new MethodProphecyException("The method \"$this->methodName\" has a void return type", $this);
         }
 
         return $this->will(new Promise\ReturnPromise(func_get_args()));
@@ -189,7 +189,7 @@ class MethodProphecy
     public function willReturnArgument($index = 0)
     {
         if ($this->voidReturnType) {
-            throw new MethodProphecyException('This method has a void return type', $this);
+            throw new MethodProphecyException("The method \"$this->methodName\" has a void return type", $this);
         }
 
         return $this->will(new Promise\ReturnArgumentPromise($index));

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -297,7 +297,7 @@ class MethodProphecy
             ));
         }
 
-        if (null === $this->promise) {
+        if (null === $this->promise && !$this->voidReturnType) {
             $this->willReturn();
         }
 

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -33,6 +33,7 @@ class MethodProphecy
     private $prediction;
     private $checkedPredictions = array();
     private $bound = false;
+    private $voidReturnType = false;
 
     /**
      * Initializes method prophecy.
@@ -71,6 +72,11 @@ class MethodProphecy
 
         if (version_compare(PHP_VERSION, '7.0', '>=') && true === $reflectedMethod->hasReturnType()) {
             $type = (string) $reflectedMethod->getReturnType();
+
+            if ('void' === $type) {
+                $this->voidReturnType = true;
+            }
+
             $this->will(function () use ($type) {
                 switch ($type) {
                     case 'string': return '';
@@ -78,6 +84,7 @@ class MethodProphecy
                     case 'int':    return 0;
                     case 'bool':   return false;
                     case 'array':  return array();
+                    case 'void':   return;
 
                     case 'callable':
                     case 'Closure':
@@ -163,6 +170,10 @@ class MethodProphecy
      */
     public function willReturn()
     {
+        if ($this->voidReturnType) {
+            throw new MethodProphecyException('This method has a void return type', $this);
+        }
+
         return $this->will(new Promise\ReturnPromise(func_get_args()));
     }
 
@@ -177,6 +188,10 @@ class MethodProphecy
      */
     public function willReturnArgument($index = 0)
     {
+        if ($this->voidReturnType) {
+            throw new MethodProphecyException('This method has a void return type', $this);
+        }
+
         return $this->will(new Promise\ReturnArgumentPromise($index));
     }
 

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -75,6 +75,7 @@ class MethodProphecy
 
             if ('void' === $type) {
                 $this->voidReturnType = true;
+                return;
             }
 
             $this->will(function () use ($type) {
@@ -84,7 +85,6 @@ class MethodProphecy
                     case 'int':    return 0;
                     case 'bool':   return false;
                     case 'array':  return array();
-                    case 'void':   return;
 
                     case 'callable':
                     case 'Closure':


### PR DESCRIPTION
Revival of @prolic's excellent work on https://github.com/phpspec/prophecy/pull/287.  Changes:
- Rebased
- Adds commit fixing build failure caused by use of void return types in class generation with PHP 7.0.