### PR TITLE
Fixed typo in MethodName case usage

### DIFF
--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -117,7 +117,7 @@ class MethodNode
                 $this->returnType = null;
                 break;
 
-            case 'string';
+            case 'string':
             case 'float':
             case 'int':
             case 'bool':


### PR DESCRIPTION
Fellow Prophecy devs,

I’ve fixed Bug in MethodName.php => on line 119 **case 'string';** semicolon was used instead of **case 'string':** colon usage. I have fixed it in the branch named “semicolon-fix” in my fork. Thanks, and I hope you will find my pull-request reasonable enough to be merged to master.

Cheers,
Mentor