### PR TITLE
feature: DateTimeToken for datetime with delta related assertions

### DIFF
--- a/spec/Prophecy/Argument/Token/DateTimeDeltaTokenSpec.php
+++ b/spec/Prophecy/Argument/Token/DateTimeDeltaTokenSpec.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace spec\Prophecy\Argument\Token;
+
+use PhpSpec\ObjectBehavior;
+
+class DateTimeDeltaTokenSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(new \DateTime(), 12);
+    }
+
+    function it_implements_TokenInterface()
+    {
+        $this->shouldBeAnInstanceOf('Prophecy\Argument\Token\TokenInterface');
+    }
+
+    function it_is_not_last()
+    {
+        $this->shouldNotBeLast();
+    }
+
+    function it_scores_true_if_datetime_is_in_delta()
+    {
+        $d1 = new \DateTime('2017-01-21 12:10:00');
+        $d2 = new \DateTime('2017-01-21 12:10:30');
+
+        $this->beConstructedWith($d1, 40);
+
+        $this->scoreArgument($d2)->shouldReturn(true);
+    }
+
+    function it_scores_false_if_datetime_is_not_in_delta()
+    {
+        $d1 = new \DateTime('2017-01-21 12:10:00');
+        $d2 = new \DateTime('2017-01-21 12:10:30');
+
+        $this->beConstructedWith($d1, 20);
+
+        $this->scoreArgument($d2)->shouldReturn(false);
+    }
+
+    function it_represents_the_object_as_string_with_the_right_format()
+    {
+        $d = new \DateTime('2017-01-21 12:10:00');
+
+        $this->beConstructedWith($d, 20);
+
+        $this->__toString()->shouldReturn('Date{2017-01-21 12:10:00}~20');
+    }
+}

--- a/src/Prophecy/Argument.php
+++ b/src/Prophecy/Argument.php
@@ -209,4 +209,18 @@ class Argument
     {
         return new Token\ApproximateValueToken($value, $precision);
     }
+
+    /**
+     * Check that the argument is matched on the seconds delta of the
+     * datetime object compared in the tests.
+     *
+     * @param \DateTimeInterface $dateTime
+     * @param int $precision
+     *
+     * @return Token\DateTimeDeltaToken
+     */
+    public static function dateInDelta(\DateTimeInterface $dateTime, $precision = 0)
+    {
+        return new Token\DateTimeDeltaToken($dateTime, $precision);
+    }
 }

--- a/src/Prophecy/Argument/Token/DateTimeDeltaToken.php
+++ b/src/Prophecy/Argument/Token/DateTimeDeltaToken.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Prophecy\Argument\Token;
+
+
+class DateTimeDeltaToken implements TokenInterface
+{
+    /** @var \DateTime */
+    private $value;
+    /** @var integer */
+    private $delta;
+
+    public function __construct(\DateTimeInterface $value, $delta)
+    {
+        $this->value = $value;
+        $this->delta = $delta;
+    }
+
+    /**
+     * Calculates token match score for provided argument.
+     *
+     * @param $argument
+     *
+     * @return bool|int
+     */
+    public function scoreArgument($argument)
+    {
+        if (!$argument instanceof \DateTimeInterface) {
+            return false;
+        }
+
+        return abs($argument->getTimestamp() - $this->value->getTimestamp()) < $this->delta;
+    }
+
+    /**
+     * Returns true if this token prevents check of other tokens (is last one).
+     *
+     * @return bool|int
+     */
+    public function isLast()
+    {
+        return false;
+    }
+
+    /**
+     * Returns string representation for token.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return sprintf('Date{%s}~%d', $this->value->format('Y-m-d H:i:s'), $this->delta);
+    }
+}


### PR DESCRIPTION
A DateTime Token that allows to check if a argument received on a function is a datetime inside a delta precision measured on seconds.