### PR TITLE
Add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/CONTRIBUTING.md export-ignore
+/fixtures/ export-ignore
+/phpunit.xml.dist export-ignore
+/spec/ export-ignore
+/tests/ export-ignore


### PR DESCRIPTION
Used by composer to ignore tests and other development files in the
distribution of a release.