### PR TITLE
Allow PHP5 keywords methods generation on PHP7.

### DIFF
--- a/spec/Prophecy/Doubler/ClassPatch/KeywordPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/KeywordPatchSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Prophecy\Doubler\ClassPatch;
 
+use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Prophecy\Doubler\Generator\Node\ClassNode;
@@ -25,6 +26,8 @@ class KeywordPatchSpec extends ObjectBehavior
         MethodNode $method2,
         MethodNode $method3
     ) {
+        $this->skipIfPhp7();
+
         $node->removeMethod('eval')->shouldBeCalled();
         $node->removeMethod('echo')->shouldBeCalled();
 
@@ -39,5 +42,12 @@ class KeywordPatchSpec extends ObjectBehavior
         ));
 
         $this->apply($node);
+    }
+
+    private function skipIfPhp7()
+    {
+        if (\PHP_VERSION_ID >= 70000) {
+            throw new SkippingException('Reserved keywords list in PHP 7 does not include most of PHP 5.6 keywords');
+        }
     }
 }

--- a/spec/Prophecy/Doubler/ClassPatch/KeywordPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/KeywordPatchSpec.php
@@ -26,7 +26,9 @@ class KeywordPatchSpec extends ObjectBehavior
         MethodNode $method2,
         MethodNode $method3
     ) {
-        $this->skipIfPhp7();
+        if (\PHP_VERSION_ID >= 70000) {
+            throw new SkippingException('Reserved keywords list in PHP 7 does not include most of PHP 5.6 keywords');
+        }
 
         $node->removeMethod('eval')->shouldBeCalled();
         $node->removeMethod('echo')->shouldBeCalled();
@@ -44,10 +46,28 @@ class KeywordPatchSpec extends ObjectBehavior
         $this->apply($node);
     }
 
-    private function skipIfPhp7()
-    {
-        if (\PHP_VERSION_ID >= 70000) {
+    function it_will_remove_halt_compiler_method(
+        ClassNode $node,
+        MethodNode $method1,
+        MethodNode $method2,
+        MethodNode $method3
+    ) {
+        if (\PHP_VERSION_ID < 70000) {
             throw new SkippingException('Reserved keywords list in PHP 7 does not include most of PHP 5.6 keywords');
         }
+
+        $node->removeMethod('__halt_compiler')->shouldBeCalled();
+
+        $method1->getName()->willReturn('__halt_compiler');
+        $method2->getName()->willReturn('echo');
+        $method3->getName()->willReturn('notKeyword');
+
+        $node->getMethods()->willReturn(array(
+            '__halt_compiler' => $method1,
+            'echo' => $method2,
+            'notKeyword' => $method3,
+        ));
+
+        $this->apply($node);
     }
 }

--- a/src/Prophecy/Doubler/ClassPatch/KeywordPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/KeywordPatch.php
@@ -51,7 +51,8 @@ class KeywordPatch implements ClassPatchInterface
      *
      * @return int Priority number (higher - earlier)
      */
-    public function getPriority() {
+    public function getPriority()
+    {
         return 49;
     }
 
@@ -60,7 +61,11 @@ class KeywordPatch implements ClassPatchInterface
      *
      * @return array
      */
-    private function getKeywords() {
+    private function getKeywords()
+    {
+        if (\PHP_VERSION_ID >= 70000) {
+            return array('__halt_compiler');
+        }
 
         return array(
             '__halt_compiler',


### PR DESCRIPTION
This is the fix of the PR #309 as it's not being updated.