### PR TITLE
Remove broken requirement of php7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php":                               "^5.3|^7.0",
         "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
         "sebastian/comparator":              "^1.1|^2.0",
-        "doctrine/instantiator":             "^1.0.2",
+        "doctrine/instantiator":             "1.0.2",
         "sebastian/recursion-context":       "^1.0|^2.0|^3.0"
     },
 


### PR DESCRIPTION
prophecy has a requirement of "doctrine/instantiator": "^1.0.2"; as of  22/07/2017 the dependency package doctrine/instantiator requires php: ^7.1 which breaks backwards compatibility with php 5.x. 
Is it possible to specify a required fixed version of doctrine/instantiator" "1.0.2" instead of "^1.0.2" as the "^1.0.2" package loads 1.1.0   requires php7