### PR TITLE
Fix broken install on PHP 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php":                               "^5.3|^7.0",
         "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
         "sebastian/comparator":              "^1.1|^2.0",
-        "doctrine/instantiator":             "^1.0.2",
+        "doctrine/instantiator":             "~1.0.2",
         "sebastian/recursion-context":       "^1.0|^2.0|^3.0"
     },
 


### PR DESCRIPTION
Keep `doctrine/instantiator` in `1.0.*` version to support PHP 7.0
**NOTE**: http://doctrine-project.org/2017/07/25/php-7.1-requirement-and-composer.html