### PR TITLE
[WIP] Allow nullable typehinted arguments [PHP 7.1]

### DIFF
--- a/fixtures/WithNullableArguments.php
+++ b/fixtures/WithNullableArguments.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Fixtures\Prophecy;
+
+class WithNullableArguments
+{
+    public function methodWithArgs(bool $arg_1 = true, ?bool $arg_2, ?bool $arg_3 = true, ?bool $arg_4 = null)
+    {
+    }
+}

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -135,7 +135,7 @@ class ClassCodeGenerator
 
             $php .= '$'.$argument->getName();
 
-            if ($argument->isOptional() && !$argument->isVariadic()) {
+            if ($argument->hasDefault()) {
                 $php .= ' = '.var_export($argument->getDefault(), true);
             }
 

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -16,6 +16,7 @@ use Prophecy\Exception\Doubler\ClassMirrorException;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionParameter;
+use ReflectionType;
 
 /**
  * Class mirror.
@@ -177,6 +178,10 @@ class ClassMirror
 
         $node->setTypeHint($this->getTypeHint($parameter));
 
+        if ($this->isNullableTypeHint($parameter)) {
+            $node->setAsNullable();
+        }
+
         if ($this->isVariadic($parameter)) {
             $node->setAsVariadic();
         }
@@ -243,6 +248,11 @@ class ClassMirror
     private function isNullable(ReflectionParameter $parameter)
     {
         return $parameter->allowsNull() && null !== $this->getTypeHint($parameter);
+    }
+
+    private function isNullableTypeHint(ReflectionParameter $parameter)
+    {
+        return version_compare(PHP_VERSION, '7.1', '>=') && true === $parameter->hasType() && true === $parameter->getType()->allowsNull();
     }
 
     private function getParameterClassName(ReflectionParameter $parameter)

--- a/tests/Doubler/Generator/ClassMirrorTest.php
+++ b/tests/Doubler/Generator/ClassMirrorTest.php
@@ -117,6 +117,50 @@ class ClassMirrorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     */
+    public function it_properly_reads_methods_nullable_arguments_with_types()
+    {
+        $this->prophesize('Fixtures\Prophecy\WithNullableArguments');
+        $class = new \ReflectionClass('Fixtures\Prophecy\WithNullableArguments');
+
+        $mirror = new ClassMirror();
+
+        $classNode = $mirror->reflect($class, array());
+        $methodNode = $classNode->getMethod('methodWithArgs');
+        $argNodes = $methodNode->getArguments();
+
+        $this->assertCount(4, $argNodes);
+
+        $this->assertEquals('arg_1', $argNodes[0]->getName());
+        $this->assertEquals('bool', $argNodes[0]->getTypeHint());
+        $this->assertTrue($argNodes[0]->isOptional());
+        $this->assertEquals(true, $argNodes[0]->getDefault());
+        $this->assertFalse($argNodes[0]->isPassedByReference());
+        $this->assertFalse($argNodes[0]->isVariadic());
+
+        $this->assertEquals('arg_2', $argNodes[1]->getName());
+        $this->assertEquals('bool', $argNodes[1]->getTypeHint());
+        $this->assertTrue($argNodes[1]->isOptional());
+
+        $this->assertEquals('arg_3', $argNodes[2]->getName());
+        $this->assertEquals('bool', $argNodes[2]->getTypeHint());
+        $this->assertTrue($argNodes[2]->isOptional());
+        $this->assertTrue($argNodes[2]->isNullable());
+        $this->assertEquals(true, $argNodes[2]->getDefault());
+        $this->assertFalse($argNodes[2]->isPassedByReference());
+        $this->assertFalse($argNodes[2]->isVariadic());
+
+        $this->assertEquals('arg_4', $argNodes[3]->getName());
+        $this->assertEquals('bool', $argNodes[3]->getTypeHint());
+        $this->assertTrue($argNodes[3]->isOptional());
+        $this->assertTrue($argNodes[3]->isNullable());
+        $this->assertNull($argNodes[3]->getDefault());
+        $this->assertFalse($argNodes[3]->isPassedByReference());
+        $this->assertFalse($argNodes[3]->isVariadic());
+    }
+
+    /**
+     * @test
      * @requires PHP 5.4
      */
     public function it_properly_reads_methods_arguments_with_callable_types()
@@ -428,6 +472,7 @@ class ClassMirrorTest extends \PHPUnit_Framework_TestCase
         $class = $this->prophesize('ReflectionClass');
         $method = $this->prophesize('ReflectionMethod');
         $parameter = $this->prophesize('ReflectionParameter');
+        $type = $this->prophesize('ReflectionType');
 
         $class->getName()->willReturn('Custom\ClassName');
         $class->isInterface()->willReturn(false);
@@ -449,10 +494,17 @@ class ClassMirrorTest extends \PHPUnit_Framework_TestCase
         $parameter->getName()->willReturn('...');
         $parameter->isDefaultValueAvailable()->willReturn(true);
         $parameter->getDefaultValue()->willReturn(null);
+        $parameter->isOptional()->willReturn(false);
+        $parameter->allowsNull()->willReturn(false);
         $parameter->isPassedByReference()->willReturn(false);
         $parameter->getClass()->willReturn($class);
         if (version_compare(PHP_VERSION, '5.6', '>=')) {
             $parameter->isVariadic()->willReturn(false);
+        }
+        if (version_compare(PHP_VERSION, '7.1', '>=')) {
+            $parameter->hasType()->willReturn(true);
+            $parameter->getType()->willReturn($type);
+            $type->allowsNull()->willReturn(true);
         }
 
         $mirror = new ClassMirror();


### PR DESCRIPTION
In a project we are using variadic arguments. In PHP 7.1 we now have the power of nullable type hints and return types. You can even do nullable typehinted variadic arguments like this:
```php
function send(?Message ...$messages) {
    foreach ($messages as $message) {
        if (null === $message) {
            continue;
        }

        // send 
    }
}

send(new Message(), null, new Message());
```

This works fine. But it doesn't work in PHPSpec:
```
warning: Declaration of Double\MailService\P2306::addMessageAndSend(Message ...$messages): void should be compatible with MailService::addMessageAndSend(?Message ...$messages): void in vendor/phpspec/prophecy/src/Prophecy/Doubler/Generator/ClassCreator.php(49)
```

I already solved this issue in [PHPUnit's Mock Objects ](https://github.com/sebastianbergmann/phpunit-mock-objects/pull/372) and that was really easy. But it's a lot harder in this project.

Could somebody point me in the right direction here?

The issue I have currently is that this source:
```php
public function methodWithArgs(bool $arg_1 = true, ?bool $arg_2, ?bool $arg_3 = true, ?bool $arg_4 = null)
```

becomes this:
```php
public  function methodWithArgs(bool $arg_1 = true, ?bool $arg_2 = NULL, ?bool $arg_3 = true, ?bool $arg_4 = NULL)
```

The second argument should not have ` = NULL` 