### PR TITLE
Escape file path sent to \SplFileObjectConstructor when running on Windows

### DIFF
--- a/src/Prophecy/Doubler/ClassPatch/SplFileInfoPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/SplFileInfoPatch.php
@@ -61,7 +61,8 @@ class SplFileInfoPatch implements ClassPatchInterface
         }
 
         if ($this->nodeIsSplFileObject($node)) {
-            $constructor->setCode('return parent::__construct("' . __FILE__ .'");');
+            $filePath = str_replace('\\','\\\\',__FILE__);
+            $constructor->setCode('return parent::__construct("' . $filePath .'");');
 
             return;
         }


### PR DESCRIPTION
I ran into problems mocking SplFileObject on Windows as the backslashes in the path produced by __FILE__ aren't escaped. Making this change to escape the path appeared to fix the problem.

I've not made any spec changes because it's a small change and I wasn't quite sure how best to go about it. 