### PR TITLE
Add shouldBeCalledOnce, *Twice

### DIFF
--- a/spec/Prophecy/Prophecy/MethodProphecySpec.php
+++ b/spec/Prophecy/Prophecy/MethodProphecySpec.php
@@ -171,6 +171,22 @@ class MethodProphecySpec extends ObjectBehavior
         $this->getPrediction()->shouldBeAnInstanceOf('Prophecy\Prediction\CallTimesPrediction');
     }
 
+    function it_adds_CallTimesPrediction_during_shouldBeCalledOnce_call($objectProphecy)
+    {
+        $objectProphecy->addMethodProphecy($this)->willReturn(null);
+
+        $this->callOnWrappedObject('shouldBeCalledOnce');
+        $this->getPrediction()->shouldBeAnInstanceOf('Prophecy\Prediction\CallTimesPrediction');
+    }
+
+    function it_adds_CallTimesPrediction_during_shouldBeCalledTwice_call($objectProphecy)
+    {
+        $objectProphecy->addMethodProphecy($this)->willReturn(null);
+
+        $this->callOnWrappedObject('shouldBeCalledTwice');
+        $this->getPrediction()->shouldBeAnInstanceOf('Prophecy\Prediction\CallTimesPrediction');
+    }
+
     function it_checks_prediction_via_shouldHave_method_call(
         $objectProphecy,
         ArgumentsWildcard $arguments,

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -279,6 +279,30 @@ class MethodProphecy
     }
 
     /**
+     * Sets call times prediction to the prophecy.
+     *
+     * @see \Prophecy\Prediction\CallTimesPrediction
+     *
+     * @return $this
+     */
+    public function shouldBeCalledOnce()
+    {
+        return $this->shouldBeCalledTimes(1);
+    }
+
+    /**
+     * Sets call times prediction to the prophecy.
+     *
+     * @see \Prophecy\Prediction\CallTimesPrediction
+     *
+     * @return $this
+     */
+    public function shouldBeCalledTwice()
+    {
+        return $this->shouldBeCalledTimes(2);
+    }
+
+    /**
      * Checks provided prediction immediately.
      *
      * @param callable|Prediction\PredictionInterface $prediction
@@ -370,6 +394,30 @@ class MethodProphecy
     public function shouldHaveBeenCalledTimes($count)
     {
         return $this->shouldHave(new Prediction\CallTimesPrediction($count));
+    }
+
+    /**
+     * Checks call times prediction.
+     *
+     * @see \Prophecy\Prediction\CallTimesPrediction
+     *
+     * @return $this
+     */
+    public function shouldHaveBeenCalledOnce()
+    {
+        return $this->shouldHaveBeenCalledTimes(1);
+    }
+
+    /**
+     * Checks call times prediction.
+     *
+     * @see \Prophecy\Prediction\CallTimesPrediction
+     *
+     * @return $this
+     */
+    public function shouldHaveBeenCalledTwice()
+    {
+        return $this->shouldHaveBeenCalledTimes(2);
     }
 
     /**


### PR DESCRIPTION
Hi,

This PR adds the methods `shouldBeCalledOnce()` and `shouldBeCalledTwice()`, that could be used instead of `shouldBeCalledTimes(1)` and `shouldBeCalledTimes(2)`.

I updated the tests, but I'm not sure how to test that _times_ is actually set to 1 or 2. If you're OK with the idea, I'll need a little help improving the tests.