### PR TITLE
[bug] CallbackPromise/CallbackPrediction Try to bind to static lambda.

### DIFF
--- a/src/Prophecy/Prediction/CallbackPrediction.php
+++ b/src/Prophecy/Prediction/CallbackPrediction.php
@@ -56,7 +56,7 @@ class CallbackPrediction implements PredictionInterface
     {
         $callback = $this->callback;
 
-        if ($callback instanceof Closure && method_exists('Closure', 'bind')) {
+        if ($callback instanceof Closure && method_exists('Closure', 'bind') && null === (new \ReflectionFunction($callback))->getClosureScopeClass()) {
             $callback = Closure::bind($callback, $object);
         }
 

--- a/src/Prophecy/Promise/CallbackPromise.php
+++ b/src/Prophecy/Promise/CallbackPromise.php
@@ -57,7 +57,7 @@ class CallbackPromise implements PromiseInterface
     {
         $callback = $this->callback;
 
-        if ($callback instanceof Closure && method_exists('Closure', 'bind')) {
+        if ($callback instanceof Closure && method_exists('Closure', 'bind') && null === (new \ReflectionFunction($callback))->getClosureScopeClass()) {
             $callback = Closure::bind($callback, $object);
         }
 

--- a/tests/Promise/CallbackPromiseTest.php
+++ b/tests/Promise/CallbackPromiseTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Prophecy\Promise;
+
+/**
+ * @internal
+ */
+final class CallbackPromiseTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCallbackPromise()
+    {
+        $fixer = $this->prophesize('Tests\Prophecy\Promise\CallbackPromiseTestDummy');
+        $fixer->getName()->will(static function (array $arguments) use (&$things) {
+            return $things
+                ? 'yes'
+                : 'no'
+            ;
+        });
+
+        $this->assertSame('no', $fixer->reveal()->getName());
+    }
+}
+
+class CallbackPromiseTestDummy
+{
+    public function getName() {
+        return 'dummy';
+    }
+}


### PR DESCRIPTION
Hi,

When doing something like:

```php
$fixer = $this->prophesize();
$fixer->willImplement(\PhpCsFixer\Fixer\DefinedFixerInterface::class);
$fixer->fix(
    Argument::type(\SplFileInfo::class),
    Argument::type(\PhpCsFixer\Tokenizer\Tokens::class)
)->will(static function (array $arguments) use (&$things) {
});
```

it will fail with a message like;

```
[03:16 PM]-[possum@zoo1]-[/home/possum/work/prophecy]-[git master] 
$ ./vendor/bin/phpunit tests/Promise/CallbackPromiseTest.php
PHPUnit 5.7.23 by Sebastian Bergmann and contributors.

E                                                                   1 / 1 (100%)

Time: 49 ms, Memory: 4.00MB

There was 1 error:

1) Tests\Prophecy\Promise\CallbackPromiseTest::testCallbackPromise
Cannot bind an instance to a static closure

/home/possum/work/prophecy/tests/Promise/CallbackPromiseTest.php:22

ERRORS!
```

This is because `CallbackPromise` (and `CallbackPrediction`) try to bind to a static lambda,
which is not allowed.

For ref.: 
- http://php.net/manual/en/closure.bindto.php
- http://php.net/manual/en/functions.anonymous.php#functions.anonymous-functions.static (`bindTo` note)
- real example demonstrating the issue; https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3187/files#diff-16ba030c9b715a9ab3427b5ba9c3ea25R241
