### PR TITLE
Re-add testing on PHP 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ matrix:
     - php: 5.6
     - php: 7.0
     - php: 7.1
+    - php: 5.3
+      dist: precise
     # Use the newer stack for HHVM as HHVM does not support Precise anymore since a long time and so Precise has an outdated version
     - php: hhvm
-      sudo: required
       dist: trusty
-      group: edge
   fast_finish: true
 
 install:


### PR DESCRIPTION
Removing CI on 5.3 without removing support in composer.json is the best way to produce broken releases for which composer cannot help us.