### PR TITLE
Added support to Symfony Finder SplFileInfo

### DIFF
--- a/spec/Prophecy/Doubler/ClassPatch/SplFileInfoPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/SplFileInfoPatchSpec.php
@@ -82,4 +82,17 @@ class SplFileInfoPatchSpec extends ObjectBehavior
 
         $this->apply($node);
     }
+
+    function it_should_supply_a_file_for_a_symfony_spl_file_info(ClassNode $node, MethodNode $method)
+    {
+        $node->hasMethod('__construct')->willReturn(true);
+        $node->getMethod('__construct')->willReturn($method);
+        $node->getParentClass()->willReturn('Symfony\\Component\\Finder\\SplFileInfo');
+
+        $method->setCode(Argument::that(function($value) {
+            return strpos($value, '.php') !== false;
+        }))->shouldBeCalled();
+
+        $this->apply($node);
+    }
 }

--- a/src/Prophecy/Doubler/ClassPatch/SplFileInfoPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/SplFileInfoPatch.php
@@ -34,7 +34,6 @@ class SplFileInfoPatch implements ClassPatchInterface
         if (null === $node->getParentClass()) {
             return false;
         }
-
         return 'SplFileInfo' === $node->getParentClass()
             || is_subclass_of($node->getParentClass(), 'SplFileInfo')
         ;
@@ -63,6 +62,13 @@ class SplFileInfoPatch implements ClassPatchInterface
         if ($this->nodeIsSplFileObject($node)) {
             $filePath = str_replace('\\','\\\\',__FILE__);
             $constructor->setCode('return parent::__construct("' . $filePath .'");');
+
+            return;
+        }
+
+        if ($this->nodeIsSymfonySplFileInfo($node)) {
+            $filePath = str_replace('\\','\\\\',__FILE__);
+            $constructor->setCode('return parent::__construct("' . $filePath .'", "", "");');
 
             return;
         }
@@ -102,5 +108,16 @@ class SplFileInfoPatch implements ClassPatchInterface
 
         return 'SplFileObject' === $parent
             || is_subclass_of($parent, 'SplFileObject');
+    }
+
+    /**
+     * @param ClassNode $node
+     * @return boolean
+     */
+    private function nodeIsSymfonySplFileInfo(ClassNode $node)
+    {
+        $parent = $node->getParentClass();
+
+        return 'Symfony\\Component\\Finder\\SplFileInfo' === $parent;
     }
 }


### PR DESCRIPTION
In Symfony 4, SplFileInfo provided by the Finder component requires its
constructor arguments to be strings
(see
https://github.com/symfony/symfony/commit/aaf2265203cfbefa006f0358077d8ade790ad203#diff-1c5661d50aeb4ac4fc0f6c0566fc2196L29).

This brings a few issues in phpspec (see
https://github.com/phpspec/phpspec/pull/1166#issuecomment-345616165),
this patch aims at fixing those issues.

Hopefully this patch isn't to farfetched, I assumed it was OK as there
are already a couple of patches for SplFileInfo.