### PR TITLE
Document another possible argument type

### DIFF
--- a/src/Prophecy/Exception/Doubler/MethodNotFoundException.php
+++ b/src/Prophecy/Exception/Doubler/MethodNotFoundException.php
@@ -14,7 +14,7 @@ namespace Prophecy\Exception\Doubler;
 class MethodNotFoundException extends DoubleException
 {
     /**
-     * @var string
+     * @var string|object
      */
     private $classname;
 
@@ -30,7 +30,7 @@ class MethodNotFoundException extends DoubleException
 
     /**
      * @param string $message
-     * @param string $classname
+     * @param string|object $classname
      * @param string $methodName
      * @param null|Argument\ArgumentsWildcard|array $arguments
      */


### PR DESCRIPTION
This class is sometimes instanciated in the codebase with objects rather
than strings, and used in phpspec by php functions able to deal with
both types.

See #369
See https://github.com/phpspec/phpspec/pull/1180