### PR TITLE
Don't truncate strings by default

### DIFF
--- a/src/Prophecy/Util/StringUtil.php
+++ b/src/Prophecy/Util/StringUtil.php
@@ -20,6 +20,16 @@ use Prophecy\Call\Call;
  */
 class StringUtil
 {
+    private $verbose;
+
+    /**
+     * @param bool $verbose
+     */
+    public function __construct($verbose = true)
+    {
+        $this->verbose = $verbose;
+    }
+
     /**
      * Stringifies any provided value.
      *
@@ -54,7 +64,7 @@ class StringUtil
         if (is_string($value)) {
             $str = sprintf('"%s"', str_replace("\n", '\\n', $value));
 
-            if (50 <= strlen($str)) {
+            if (!$this->verbose && 50 <= strlen($str)) {
                 return substr($str, 0, 50).'"...';
             }
 


### PR DESCRIPTION
Closes #340.

This behavior is very annoying:

```
  - getCollection("ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity"...)
on Double\CollectionDataProviderInterface\P16 was not expected, expected calls were:
  - getCollection(exact("ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity"...))
```

With this change:

```
Prophecy\Exception\Call\UnexpectedCallException: Method call:
  - getCollection("ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\Dummy")
on Double\CollectionDataProviderInterface\P16 was not expected, expected calls were:
  - getCollection(exact("ApiPlatform\Core\Tests\Fixtures\TestBundle\Entity\RelatedDummy"))
```
