### PR TITLE
Test against PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 
     "require-dev": {
         "phpspec/phpspec": "^2.5|^3.2",
-        "phpunit/phpunit": "^4.8.35 || ^5.7"
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
     },
 
     "autoload": {

--- a/tests/Doubler/Generator/ClassMirrorTest.php
+++ b/tests/Doubler/Generator/ClassMirrorTest.php
@@ -219,14 +219,13 @@ class ClassMirrorTest extends TestCase
 
     /**
      * @test
+     * @expectedException Prophecy\Exception\Doubler\ClassMirrorException
      */
     public function it_throws_an_exception_if_class_is_final()
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\FinalClass');
 
         $mirror = new ClassMirror();
-
-        $this->setExpectedException('Prophecy\Exception\Doubler\ClassMirrorException');
 
         $mirror->reflect($class, array());
     }
@@ -262,14 +261,13 @@ class ClassMirrorTest extends TestCase
 
     /**
      * @test
+     * @expectedException Prophecy\Exception\InvalidArgumentException
      */
     public function it_throws_an_exception_if_interface_provided_instead_of_class()
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\EmptyInterface');
 
         $mirror = new ClassMirror();
-
-        $this->setExpectedException('Prophecy\Exception\InvalidArgumentException');
 
         $mirror->reflect($class, array());
     }
@@ -354,6 +352,7 @@ class ClassMirrorTest extends TestCase
 
     /**
      * @test
+     * @expectedException InvalidArgumentException
      */
     public function it_throws_an_exception_if_class_provided_in_interfaces_list()
     {
@@ -361,19 +360,16 @@ class ClassMirrorTest extends TestCase
 
         $mirror = new ClassMirror();
 
-        $this->setExpectedException('InvalidArgumentException');
-
         $mirror->reflect(null, array($class));
     }
 
     /**
      * @test
+     * @expectedException InvalidArgumentException
      */
     public function it_throws_an_exception_if_not_reflection_provided_as_interface()
     {
         $mirror = new ClassMirror();
-
-        $this->setExpectedException('InvalidArgumentException');
 
         $mirror->reflect(null, array(null));
     }


### PR DESCRIPTION
I've added `PHPUnit 6` support. This will help us test `PHP 7.2` in #378.

I just need to use the `@expectedException` notation instead of `setExpectedException` method, as this method no longer exists in `PHPUnit 6`.