### PR TITLE
AggregateException: updated multiple exceptions message formatting

### DIFF
--- a/spec/Prophecy/Exception/Prediction/AggregateExceptionSpec.php
+++ b/spec/Prophecy/Exception/Prediction/AggregateExceptionSpec.php
@@ -45,6 +45,20 @@ class AggregateExceptionSpec extends ObjectBehavior
 
         $this->append($exception);
 
-        $this->getMessage()->shouldReturn("  Exception #1");
+        $this->getMessage()->shouldReturn('Exception #1');
+    }
+
+    function it_should_update_message_during_append_more_exceptions(
+        PredictionException $exception1,
+        PredictionException $exception2
+    ) {
+        $exception1->getMessage()->willReturn('Exception #1');
+        $exception2->getMessage()->willReturn('Exception #2');
+
+        $this->append($exception1);
+        $this->getMessage()->shouldReturn('Exception #1');
+
+        $this->append($exception2);
+        $this->getMessage()->shouldReturn("Exception #1\nException #2");
     }
 }

--- a/src/Prophecy/Exception/Prediction/AggregateException.php
+++ b/src/Prophecy/Exception/Prediction/AggregateException.php
@@ -21,7 +21,8 @@ class AggregateException extends \RuntimeException implements PredictionExceptio
     public function append(PredictionException $exception)
     {
         $message = $exception->getMessage();
-        $message = '  '.strtr($message, array("\n" => "\n  "))."\n";
+        $message = strtr($message, array("\n" => "\n  "))."\n";
+        $message = empty($this->exceptions) ? $message : "\n" . $message;
 
         $this->message      = rtrim($this->message.$message);
         $this->exceptions[] = $exception;


### PR DESCRIPTION
When there are multiple exceptions aggregated the old behavior was hard to read because next message was appended on the same line as previous, separated only by two spaces. I've updated that so every message begins on a new line.

Old look:
```
1742  - it should increase bundles quantity when adding same bundle
      some predictions failed:
        Double\Dory\Checkout\Domain\Entity\Bundle\P197:
          No calls have been made that match:
            Double\Dory\Checkout\Domain\Entity\Bundle\P197->getBundleProducts()
          but expected at least one.  No calls have been made that match:
            Double\Dory\Checkout\Domain\Entity\Bundle\P197->getFulfilmentChannel()
          but expected at least one.  No calls have been made that match:
            Double\Dory\Checkout\Domain\Entity\Bundle\P197->getCollectionMethod()
          but expected at least one.
```

New look:
```
1742  - it should increase bundles quantity when adding same bundle
      some predictions failed:
      Double\Dory\Checkout\Domain\Entity\Bundle\P197:
        No calls have been made that match:
            Double\Dory\Checkout\Domain\Entity\Bundle\P197->getBundleProducts()
          but expected at least one.
        No calls have been made that match:
            Double\Dory\Checkout\Domain\Entity\Bundle\P197->getFulfilmentChannel()
          but expected at least one.
        No calls have been made that match:
            Double\Dory\Checkout\Domain\Entity\Bundle\P197->getCollectionMethod()
          but expected at least one.
```