### PR TITLE
Generate proper object return type

### DIFF
--- a/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
@@ -17,6 +17,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         MethodNode $method2,
         MethodNode $method3,
         MethodNode $method4,
+        MethodNode $method5,
         ArgumentNode $argument11,
         ArgumentNode $argument12,
         ArgumentNode $argument13,
@@ -28,7 +29,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
             'Prophecy\Doubler\Generator\MirroredInterface', 'ArrayAccess', 'ArrayIterator'
         ));
         $class->getProperties()->willReturn(array('name' => 'public', 'email' => 'private'));
-        $class->getMethods()->willReturn(array($method1, $method2, $method3, $method4));
+        $class->getMethods()->willReturn(array($method1, $method2, $method3, $method4, $method5));
 
         $method1->getName()->willReturn('getName');
         $method1->getVisibility()->willReturn('public');
@@ -68,6 +69,16 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method4->getReturnType()->willReturn('void');
         $method4->hasNullableReturnType()->willReturn(false);
         $method4->getCode()->willReturn('return;');
+
+        $method5->getName()->willReturn('returnObject');
+        $method5->getVisibility()->willReturn('public');
+        $method5->returnsReference()->willReturn(false);
+        $method5->isStatic()->willReturn(false);
+        $method5->getArguments()->willReturn(array());
+        $method5->hasReturnType()->willReturn(true);
+        $method5->getReturnType()->willReturn(version_compare(PHP_VERSION, '7.2', '>=') ? 'object' : '\object');
+        $method5->hasNullableReturnType()->willReturn(false);
+        $method5->getCode()->willReturn('return;');
 
         $argument11->getName()->willReturn('fullname');
         $argument11->getTypeHint()->willReturn('array');
@@ -128,6 +139,9 @@ return $this->refValue;
 public  function doSomething(): void {
 return;
 }
+public  function returnObject(): object {
+return;
+}
 
 }
 }
@@ -149,6 +163,9 @@ public  function &getRefValue( $refValue): string {
 return $this->refValue;
 }
 public  function doSomething(): void {
+return;
+}
+public  function returnObject(): \object {
 return;
 }
 
@@ -174,6 +191,9 @@ return $this->refValue;
 public  function doSomething() {
 return;
 }
+public  function returnObject(): \object {
+return;
+}
 
 }
 }
@@ -195,6 +215,9 @@ public  function &getRefValue( $refValue) {
 return $this->refValue;
 }
 public  function doSomething() {
+return;
+}
+public  function returnObject() {
 return;
 }
 

--- a/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
+++ b/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
@@ -124,7 +124,7 @@ class MethodNodeSpec extends ObjectBehavior
 
     function it_setReturnType_sets_return_type()
     {
-        $returnType = 'string';
+        $returnType = 'array';
 
         $this->setReturnType($returnType);
 

--- a/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
+++ b/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
@@ -42,7 +42,7 @@ class MethodNodeSpec extends ObjectBehavior
     {
         $this->setReturnsReference();
         $this->returnsReference()->shouldReturn(true);
-    } 
+    }
 
     function it_should_be_settable_as_static_through_setter()
     {
@@ -130,5 +130,11 @@ class MethodNodeSpec extends ObjectBehavior
 
         $this->hasReturnType()->shouldReturn(true);
         $this->getReturnType()->shouldReturn($returnType);
+    }
+
+    function it_handles_object_return_type()
+    {
+        $this->setReturnType('object');
+        $this->getReturnType()->shouldReturn(version_compare(PHP_VERSION, '7.2', '>=') ? 'object' : '\object');
     }
 }

--- a/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
+++ b/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
@@ -137,4 +137,25 @@ class MethodNodeSpec extends ObjectBehavior
         $this->setReturnType('object');
         $this->getReturnType()->shouldReturn(version_compare(PHP_VERSION, '7.2', '>=') ? 'object' : '\object');
     }
+
+    function it_handles_type_aliases()
+    {
+        $this->setReturnType('double');
+        $this->getReturnType()->shouldReturn(version_compare(PHP_VERSION, '7.0', '>=') ? 'float' : '\float');
+
+        $this->setReturnType('real');
+        $this->getReturnType()->shouldReturn(version_compare(PHP_VERSION, '7.0', '>=') ? 'float' : '\float');
+
+        $this->setReturnType('boolean');
+        $this->getReturnType()->shouldReturn(version_compare(PHP_VERSION, '7.0', '>=') ? 'bool' : '\bool');
+
+        $this->setReturnType('integer');
+        $this->getReturnType()->shouldReturn(version_compare(PHP_VERSION, '7.0', '>=') ? 'int' : '\int');
+    }
+
+    function it_handles_null_return_type()
+    {
+        $this->setReturnType(null);
+        $this->getReturnType()->shouldReturn(null);
+    }
 }

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -110,11 +110,7 @@ class ClassCodeGenerator
             }
 
             if ($hint = $argument->getTypeHint()) {
-                if ($typeHintReference->isBuiltInParamTypeHint($hint)) {
-                    $php .= $hint;
-                } else {
-                    $php .= '\\'.$hint;
-                }
+                $php .= $typeHintReference->isBuiltInParamTypeHint($hint) ? $hint : '\\'.$hint;
             }
 
             $php .= ' '.($argument->isPassedByReference() ? '&' : '');

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -20,6 +20,16 @@ namespace Prophecy\Doubler\Generator;
 class ClassCodeGenerator
 {
     /**
+     * @var TypeHintReference
+     */
+    private $typeHintReference;
+
+    public function __construct(TypeHintReference $typeHintReference = null)
+    {
+        $this->typeHintReference = $typeHintReference ?: new TypeHintReference();
+    }
+
+    /**
      * Generates PHP code for class node.
      *
      * @param string         $classname
@@ -91,7 +101,8 @@ class ClassCodeGenerator
 
     private function generateArguments(array $arguments)
     {
-        return array_map(function (Node\ArgumentNode $argument) {
+        $typeHintReference = $this->typeHintReference;
+        return array_map(function (Node\ArgumentNode $argument) use ($typeHintReference) {
             $php = '';
 
             if (version_compare(PHP_VERSION, '7.1', '>=')) {
@@ -99,42 +110,10 @@ class ClassCodeGenerator
             }
 
             if ($hint = $argument->getTypeHint()) {
-                switch ($hint) {
-                    case 'array':
-                    case 'callable':
-                        $php .= $hint;
-                        break;
-
-                    case 'iterable':
-                        if (version_compare(PHP_VERSION, '7.1', '>=')) {
-                            $php .= $hint;
-                            break;
-                        }
-
-                        $php .= '\\'.$hint;
-                        break;
-
-                    case 'object':
-                        if (version_compare(PHP_VERSION, '7.2', '>=')) {
-                            $php .= $hint;
-                            break;
-                        }
-
-                        $php .= '\\'.$hint;
-                        break;
-
-                    case 'string':
-                    case 'int':
-                    case 'float':
-                    case 'bool':
-                        if (version_compare(PHP_VERSION, '7.0', '>=')) {
-                            $php .= $hint;
-                            break;
-                        }
-                        // Fall-through to default case for PHP 5.x
-
-                    default:
-                        $php .= '\\'.$hint;
+                if ($typeHintReference->isBuiltInParamTypeHint($hint)) {
+                    $php .= $hint;
+                } else {
+                    $php .= '\\'.$hint;
                 }
             }
 

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -145,11 +145,9 @@ class MethodNode
                 // Fall-through to default case for PHP < 7.2
 
             default:
-                if ($this->typeHintReference->isBuiltInReturnTypeHint($type)) {
-                    $this->returnType = $type;
-                } else {
-                    $this->returnType = '\\' . ltrim($type, '\\');
-                }
+                $this->returnType = $this->typeHintReference->isBuiltInReturnTypeHint($type) ?
+                    $type :
+                    '\\' . ltrim($type, '\\');
         }
     }
 

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -137,6 +137,13 @@ class MethodNode
                 $type = 'int';
                 // intentional fall through
 
+            case 'object':
+                if (version_compare(PHP_VERSION, '7.2', '>=')) {
+                    $this->returnType = $type;
+                    break;
+                }
+                // Fall-through to default case for PHP < 7.2
+
             default:
                 if ($this->typeHintReference->isBuiltInReturnTypeHint($type)) {
                     $this->returnType = $type;

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -11,6 +11,7 @@
 
 namespace Prophecy\Doubler\Generator\Node;
 
+use Prophecy\Doubler\Generator\TypeHintReference;
 use Prophecy\Exception\InvalidArgumentException;
 
 /**
@@ -34,13 +35,19 @@ class MethodNode
     private $arguments = array();
 
     /**
+     * @var TypeHintReference
+     */
+    private $typeHintReference;
+
+    /**
      * @param string $name
      * @param string $code
      */
-    public function __construct($name, $code = null)
+    public function __construct($name, $code = null, TypeHintReference $typeHintReference = null)
     {
         $this->name = $name;
         $this->code = $code;
+        $this->typeHintReference = $typeHintReference ?: new TypeHintReference();
     }
 
     public function getVisibility()
@@ -117,32 +124,25 @@ class MethodNode
                 $this->returnType = null;
                 break;
 
-            case 'string':
-            case 'float':
-            case 'int':
-            case 'bool':
-            case 'array':
-            case 'callable':
-            case 'iterable':
-            case 'void':
-                $this->returnType = $type;
-                break;
-
             case 'double':
             case 'real':
-                $this->returnType = 'float';
-                break;
+                $type = 'float';
+                // intentional fall through
 
             case 'boolean':
-                $this->returnType = 'bool';
-                break;
+                $type = 'bool';
+                // intentional fall through
 
             case 'integer':
-                $this->returnType = 'int';
-                break;
+                $type = 'int';
+                // intentional fall through
 
             default:
-                $this->returnType = '\\' . ltrim($type, '\\');
+                if ($this->typeHintReference->isBuiltInReturnTypeHint($type)) {
+                    $this->returnType = $type;
+                } else {
+                    $this->returnType = '\\' . ltrim($type, '\\');
+                }
         }
     }
 

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -119,36 +119,22 @@ class MethodNode
      */
     public function setReturnType($type = null)
     {
-        switch ($type) {
-            case '':
-                $this->returnType = null;
-                break;
-
-            case 'double':
-            case 'real':
-                $type = 'float';
-                // intentional fall through
-
-            case 'boolean':
-                $type = 'bool';
-                // intentional fall through
-
-            case 'integer':
-                $type = 'int';
-                // intentional fall through
-
-            case 'object':
-                if (version_compare(PHP_VERSION, '7.2', '>=')) {
-                    $this->returnType = $type;
-                    break;
-                }
-                // Fall-through to default case for PHP < 7.2
-
-            default:
-                $this->returnType = $this->typeHintReference->isBuiltInReturnTypeHint($type) ?
-                    $type :
-                    '\\' . ltrim($type, '\\');
+        if ($type === '' || $type === null) {
+            $this->returnType = null;
+            return;
         }
+        $typeMap = array(
+            'double' => 'float',
+            'real' => 'float',
+            'boolean' => 'bool',
+            'integer' => 'int',
+        );
+        if (isset($typeMap[$type])) {
+            $type = $typeMap[$type];
+        }
+        $this->returnType = $this->typeHintReference->isBuiltInReturnTypeHint($type) ?
+            $type :
+            '\\' . ltrim($type, '\\');
     }
 
     public function getReturnType()

--- a/src/Prophecy/Doubler/Generator/TypeHintReference.php
+++ b/src/Prophecy/Doubler/Generator/TypeHintReference.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Prophecy\Doubler\Generator;
+
+/**
+ * Tells whether a keyword refers to a class or to a built-in type for the
+ * current version of php
+ */
+final class TypeHintReference
+{
+    public function isBuiltInParamTypeHint($type)
+    {
+        switch ($type) {
+            case 'self':
+            case 'array':
+                return true;
+
+            case 'callable':
+                return PHP_VERSION_ID >= 50400;
+
+            case 'bool':
+            case 'float':
+            case 'int':
+            case 'string':
+                return PHP_VERSION_ID >= 70000;
+
+            case 'iterable':
+                return PHP_VERSION_ID >= 70100;
+
+            case 'object':
+                return PHP_VERSION_ID >= 70200;
+
+            default:
+                return false;
+        }
+    }
+
+    public function isBuiltInReturnTypeHint($type)
+    {
+        if ($type === 'void') {
+            return PHP_VERSION_ID >= 70100;
+        }
+
+        return $this->isBuiltInParamTypeHint($type);
+    }
+}


### PR DESCRIPTION
Generates `\object` on php < 7.2, `object` otherwise, so madmen who want to call their classes object ( or [bool](https://github.com/ruflin/Elastica/blob/2.x/lib/Elastica/Query/Bool.php)) can.
