### PR TITLE
Add shouldBeCalledOnce()

### DIFF
--- a/spec/Prophecy/Prophecy/MethodProphecySpec.php
+++ b/spec/Prophecy/Prophecy/MethodProphecySpec.php
@@ -171,6 +171,14 @@ class MethodProphecySpec extends ObjectBehavior
         $this->getPrediction()->shouldBeAnInstanceOf('Prophecy\Prediction\CallTimesPrediction');
     }
 
+    function it_adds_CallTimesPrediction_during_shouldBeCalledOnce_call($objectProphecy)
+    {
+        $objectProphecy->addMethodProphecy($this)->willReturn(null);
+
+        $this->callOnWrappedObject('shouldBeCalledOnce');
+        $this->getPrediction()->shouldBeAnInstanceOf('Prophecy\Prediction\CallTimesPrediction');
+    }
+
     function it_checks_prediction_via_shouldHave_method_call(
         $objectProphecy,
         ArgumentsWildcard $arguments,

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -279,6 +279,18 @@ class MethodProphecy
     }
 
     /**
+     * Sets call times prediction to the prophecy.
+     *
+     * @see \Prophecy\Prediction\CallTimesPrediction
+     *
+     * @return $this
+     */
+    public function shouldBeCalledOnce()
+    {
+        return $this->shouldBeCalledTimes(1);
+    }
+
+    /**
      * Checks provided prediction immediately.
      *
      * @param callable|Prediction\PredictionInterface $prediction
@@ -370,6 +382,18 @@ class MethodProphecy
     public function shouldHaveBeenCalledTimes($count)
     {
         return $this->shouldHave(new Prediction\CallTimesPrediction($count));
+    }
+
+    /**
+     * Checks call times prediction.
+     *
+     * @see \Prophecy\Prediction\CallTimesPrediction
+     *
+     * @return $this
+     */
+    public function shouldHaveBeenCalledOnce()
+    {
+        return $this->shouldHaveBeenCalledTimes(1);
     }
 
     /**


### PR DESCRIPTION
Hi,

This PR allows to write `->shouldBeCalledOnce()` instead of `->shouldBeCalledTimes(1)`. I noticed that most of the times we are using `->shouldBeCalled()` because `shouldBeCalledTimes()` is cumbersome, maybe this could help writing more accurate tests.