### PR TITLE
Added mustReturn() method to MethodProphecy

### DIFF
--- a/spec/Prophecy/Prophecy/MethodProphecySpec.php
+++ b/spec/Prophecy/Prophecy/MethodProphecySpec.php
@@ -78,6 +78,17 @@ class MethodProphecySpec extends ObjectBehavior
         $this->will($promise);
     }
 
+    function it_adds_ReturnPromise_and_CallPrediction_during_mustReturn_call($objectProphecy)
+    {
+        $objectProphecy->addMethodProphecy($this)->willReturn(null);
+
+        $this->mustReturn(42);
+        $this->getPromise()->shouldBeAnInstanceOf('Prophecy\Promise\ReturnPromise');
+
+        $this->callOnWrappedObject('shouldBeCalled', array());
+        $this->getPrediction()->shouldBeAnInstanceOf('Prophecy\Prediction\CallPrediction');
+    }
+
     function it_adds_ReturnPromise_during_willReturn_call($objectProphecy)
     {
         $objectProphecy->addMethodProphecy($this)->willReturn(null);

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -213,6 +213,25 @@ class MethodProphecy
     }
 
     /**
+     * Shorthand for willReturn()->shouldBeCalled()
+     *
+     * Sets return promise to the prophecy.
+     * Sets call prediction to the prophecy.
+     *
+     * @see \Prophecy\Promise\ReturnPromise
+     * @see \Prophecy\Prediction\CallPrediction
+     *
+     * @return $this
+     */
+     public function mustReturn()
+     {
+         /** @var self $promise */
+         $promise = call_user_func_array(array($this, 'willReturn'), func_get_args());
+
+         return $promise->shouldBeCalled();
+     }
+
+    /**
      * Sets custom prediction to the prophecy.
      *
      * @param callable|Prediction\PredictionInterface $prediction


### PR DESCRIPTION
Method combines willReturn() call with shouldBeCalled() which is frequently used together.