### PR TITLE
Fix DisableConstructorPatch breaking already-optional arguments

### DIFF
--- a/spec/Prophecy/Doubler/ClassPatch/DisableConstructorPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/DisableConstructorPatchSpec.php
@@ -35,8 +35,27 @@ class DisableConstructorPatchSpec extends ObjectBehavior
         $class->getMethod('__construct')->willReturn($method);
         $method->getArguments()->willReturn(array($arg1, $arg2));
 
+        $arg1->isOptional()->willReturn(false);
         $arg1->setDefault(null)->shouldBeCalled();
+        $arg2->isOptional()->willReturn(false);
         $arg2->setDefault(null)->shouldBeCalled();
+
+        $method->setCode(Argument::type('string'))->shouldBeCalled();
+
+        $this->apply($class);
+    }
+
+    function it_does_not_redefine_already_optional_arguments(
+        ClassNode $class,
+        MethodNode $method,
+        ArgumentNode $arg
+    ) {
+        $class->hasMethod('__construct')->willReturn(true);
+        $class->getMethod('__construct')->willReturn($method);
+        $method->getArguments()->willReturn(array($arg));
+
+        $arg->isOptional()->shouldBeCalled()->willReturn(true);
+        $arg->setDefault(Argument::any())->shouldNotBeCalled();
 
         $method->setCode(Argument::type('string'))->shouldBeCalled();
 

--- a/src/Prophecy/Doubler/ClassPatch/DisableConstructorPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/DisableConstructorPatch.php
@@ -49,7 +49,9 @@ class DisableConstructorPatch implements ClassPatchInterface
 
         $constructor = $node->getMethod('__construct');
         foreach ($constructor->getArguments() as $argument) {
-            $argument->setDefault(null);
+            if (!$argument->isOptional()) {
+                $argument->setDefault(null);
+            }
         }
 
         $constructor->setCode(<<<PHP


### PR DESCRIPTION
Currently, the `DisableConstructorPatch` always redefines all constructor arguments as optional with a default value of null, regardless of the argument's existing definition.  This is problematic in cases where the argument is already optional, is not nullable, and the original constructor is invoked.

Example:
`Symfony\Component\HttpFoundation\File\UploadedFile` has a signature of:
```php
__construct(string $path, string $originalName, string $mimeType = null, int $size = null, int $error = null, bool $test = false)
```

Providing all arguments works:
```php
$fileProph = $this->prophesize(UploadedFile::class);
$fileProph->willBeConstructedWith([__FILE__, 'example.txt', 'text/plain', 100, \UPLOAD_ERR_OK, false]);
$fileProph->reveal();
```

I expect the below to work as well, because only the first two arguments are required.  This does not currently work, because the generated double constructor has `bool $test = NULL`, which is incompatible with the original constructor.
```php
$fileProph = $this->prophesize(UploadedFile::class);
$fileProph->willBeConstructedWith([__FILE__, 'example.txt']);
$fileProph->reveal();
```

I don't believe the current behavior makes sense, optional arguments with typed defaults should have those defaults retained.
