### PR TITLE
IdenticalValueToken: Allow identity checks on objects

### DIFF
--- a/src/Prophecy/Argument/Token/IdenticalValueToken.php
+++ b/src/Prophecy/Argument/Token/IdenticalValueToken.php
@@ -21,6 +21,7 @@ use Prophecy\Util\StringUtil;
 class IdenticalValueToken implements TokenInterface
 {
     private $value;
+    private $hash;
     private $string;
     private $util;
 
@@ -34,6 +35,10 @@ class IdenticalValueToken implements TokenInterface
     {
         $this->value = $value;
         $this->util  = $util ?: new StringUtil();
+
+        if (is_object($value)) {
+            $this->hash = spl_object_hash($value);
+        }
     }
 
     /**


### PR DESCRIPTION
ObjectProphecy::__call prevents duplicate methodProphecies by
calling assertEquals on the prophecies, but identity checks
would need assertSame to work properly for objects. If we
store the spl_object_hash in the IdenticalValueToken we'll
cause inequality and let the token be used multiple times.