### PR TITLE
Drop HHVM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ matrix:
     - php: 7.2
     - php: 5.3
       dist: precise
-    # Use the newer stack for HHVM as HHVM does not support Precise anymore since a long time and so Precise has an outdated version
-    - php: hhvm
-      dist: trusty
   fast_finish: true
 
 install:


### PR DESCRIPTION
Travis has updated the HHVM version and yet again it's broken the tests

I don't think we should continue supporting it; many projects have dropped support and Facebook are concentrating on HackLang rather than supporting PHP 7 features

@stof do you have an opinion?