### PR TITLE
Do not add the method to the ClassNode when already added

### DIFF
--- a/fixtures/MethodWithAdditionalParam.php
+++ b/fixtures/MethodWithAdditionalParam.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Fixtures\Prophecy;
+
+abstract class MethodWithAdditionalParam extends WithArguments implements Named
+{
+    abstract public function getName($name = null);
+
+    public function methodWithoutTypeHints($arg, $arg2 = null)
+    {
+    }
+}

--- a/spec/Prophecy/Doubler/ClassPatch/ProphecySubjectPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/ProphecySubjectPatchSpec.php
@@ -31,8 +31,8 @@ class ProphecySubjectPatchSpec extends ObjectBehavior
         $node->addProperty('objectProphecy', 'private')->willReturn(null);
         $node->getMethods()->willReturn(array());
         $node->hasMethod(Argument::any())->willReturn(false);
-        $node->addMethod(Argument::type('Prophecy\Doubler\Generator\Node\MethodNode'))->willReturn(null);
-        $node->addMethod(Argument::type('Prophecy\Doubler\Generator\Node\MethodNode'))->willReturn(null);
+        $node->addMethod(Argument::type('Prophecy\Doubler\Generator\Node\MethodNode'), true)->willReturn(null);
+        $node->addMethod(Argument::type('Prophecy\Doubler\Generator\Node\MethodNode'), true)->willReturn(null);
 
         $this->apply($node);
     }
@@ -47,8 +47,8 @@ class ProphecySubjectPatchSpec extends ObjectBehavior
         $node->addInterface('Prophecy\Prophecy\ProphecySubjectInterface')->willReturn(null);
         $node->addProperty('objectProphecy', 'private')->willReturn(null);
         $node->hasMethod(Argument::any())->willReturn(false);
-        $node->addMethod(Argument::type('Prophecy\Doubler\Generator\Node\MethodNode'))->willReturn(null);
-        $node->addMethod(Argument::type('Prophecy\Doubler\Generator\Node\MethodNode'))->willReturn(null);
+        $node->addMethod(Argument::type('Prophecy\Doubler\Generator\Node\MethodNode'), true)->willReturn(null);
+        $node->addMethod(Argument::type('Prophecy\Doubler\Generator\Node\MethodNode'), true)->willReturn(null);
 
         $constructor->getName()->willReturn('__construct');
         $method1->getName()->willReturn('method1');

--- a/src/Prophecy/Doubler/ClassPatch/ProphecySubjectPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/ProphecySubjectPatch.php
@@ -77,7 +77,7 @@ class ProphecySubjectPatch implements ClassPatchInterface
             $__call->addArgument(new ArgumentNode('name'));
             $__call->addArgument(new ArgumentNode('arguments'));
 
-            $node->addMethod($__call);
+            $node->addMethod($__call, true);
         }
 
         $__call->setCode(<<<PHP
@@ -88,8 +88,8 @@ throw new \Prophecy\Exception\Doubler\MethodNotFoundException(
 PHP
         );
 
-        $node->addMethod($prophecySetter);
-        $node->addMethod($prophecyGetter);
+        $node->addMethod($prophecySetter, true);
+        $node->addMethod($prophecyGetter, true);
     }
 
     /**

--- a/src/Prophecy/Doubler/Generator/Node/ClassNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/ClassNode.php
@@ -100,7 +100,7 @@ class ClassNode
         return $this->methods;
     }
 
-    public function addMethod(MethodNode $method)
+    public function addMethod(MethodNode $method, $force = false)
     {
         if (!$this->isExtendable($method->getName())){
             $message = sprintf(
@@ -108,7 +108,10 @@ class ClassNode
             );
             throw new MethodNotExtendableException($message, $this->getParentClass(), $method->getName());
         }
-        $this->methods[$method->getName()] = $method;
+
+        if ($force || !isset($this->methods[$method->getName()])) {
+            $this->methods[$method->getName()] = $method;
+        }
     }
 
     public function removeMethod($name)

--- a/tests/Doubler/Generator/ClassMirrorTest.php
+++ b/tests/Doubler/Generator/ClassMirrorTest.php
@@ -418,6 +418,25 @@ class ClassMirrorTest extends TestCase
 
     /**
      * @test
+     * @requires PHP 7.2
+     */
+    function it_doesnt_fail_when_method_is_extended_with_more_params()
+    {
+        $mirror = new ClassMirror();
+
+        $classNode = $mirror->reflect(
+            new \ReflectionClass('Fixtures\Prophecy\MethodWithAdditionalParam'),
+            array(new \ReflectionClass('Fixtures\Prophecy\Named'))
+        );
+        $method = $classNode->getMethod('getName');
+        $this->assertCount(1, $method->getArguments());
+
+        $method = $classNode->getMethod('methodWithoutTypeHints');
+        $this->assertCount(2, $method->getArguments());
+    }
+
+    /**
+     * @test
      */
     function it_changes_argument_names_if_they_are_varying()
     {


### PR DESCRIPTION
`addMethod` method has now additional parameter - `force`
when the method defintion in ClassNode should be replaced.

Issue is present only in PHP 7.2, example:
```php
interface MyInterface {
    public function get();
}

class MyClass implements MyInterface {
    public function get($force = null) {};
}
```

then it is not possible to prophesize `MyClass` correctly, because method `get` first will be added with `MyClass` definition and then replaced with `MyInterface` definition, what is wrong.
