### PR TITLE
CallCenter: improved formatting for unexpected method call message

### DIFF
--- a/src/Prophecy/Call/CallCenter.php
+++ b/src/Prophecy/Call/CallCenter.php
@@ -158,32 +158,23 @@ class CallCenter
             )
         );
 
-        $expected = implode(
-            "\n",
-            array_map(
-                function (MethodProphecy $methodProphecy) use ($indentationLength) {
-                    return sprintf(
-                        "  - %s(\n".
-                        "%s\n".
-                        "    )",
-                        $methodProphecy->getMethodName(),
-                        implode(
-                            ",\n",
-                            $this->indentArguments(
-                                array_map(
-                                    function ($token) {
-                                        return (string) $token;
-                                    },
-                                    $methodProphecy->getArgumentsWildcard()->getTokens()
-                                ),
-                                $indentationLength
-                            )
-                        )
-                    );
-                },
-                call_user_func_array('array_merge', $prophecy->getMethodProphecies())
-            )
-        );
+        $expected = array();
+
+        foreach (call_user_func_array('array_merge', $prophecy->getMethodProphecies()) as $methodProphecy) {
+            $expected[] = sprintf(
+                "  - %s(\n" .
+                "%s\n" .
+                "    )",
+                $methodProphecy->getMethodName(),
+                implode(
+                    ",\n",
+                    $this->indentArguments(
+                        array_map('strval', $methodProphecy->getArgumentsWildcard()->getTokens()),
+                        $indentationLength
+                    )
+                )
+            );
+        }
 
         return new UnexpectedCallException(
             sprintf(
@@ -194,10 +185,32 @@ class CallCenter
                 "expected calls were:\n".
                 "%s",
 
-                $classname, $methodName, $argstring, $expected
+                $classname, $methodName, $argstring, implode("\n", $expected)
             ),
             $prophecy, $methodName, $arguments
 
+        );
+    }
+
+    private function formatExceptionMessage(MethodProphecy $methodProphecy)
+    {
+        return sprintf(
+            "  - %s(\n".
+            "%s\n".
+            "    )",
+            $methodProphecy->getMethodName(),
+            implode(
+                ",\n",
+                $this->indentArguments(
+                    array_map(
+                        function ($token) {
+                            return (string) $token;
+                        },
+                        $methodProphecy->getArgumentsWildcard()->getTokens()
+                    ),
+                    $indentationLength
+                )
+            )
         );
     }
 


### PR DESCRIPTION
With the original wording it is not really obvious what the message is saying. I propose the new wording which puts key words first and thus makes the message more readable. 

Old look:

```
1485  - it should do something
      method call:
        - getCollectInStoreBundles()
      on Double\Dory\Checkout\Domain\Entity\Basket\P2488 was not expected, expected calls were:
        - getCollectInStoreProducts()
        - getStore()
        - getTelesalesOperatorId()
```

New look:

```
1485  - it should do something
      unexpected method call on Double\Dory\Checkout\Domain\Entity\Basket\P2488:
        - getCollectInStoreBundles()
      expected calls were:
        - getCollectInStoreProducts()
        - getStore()
        - getTelesalesOperatorId()
```

