### PR TITLE
Make string contains token return false when value is not a string

### DIFF
--- a/spec/Prophecy/Argument/Token/StringContainsTokenSpec.php
+++ b/spec/Prophecy/Argument/Token/StringContainsTokenSpec.php
@@ -42,6 +42,11 @@ class StringContainsTokenSpec extends ObjectBehavior
         $this->scoreArgument('Argument will not match')->shouldReturn(false);
     }
 
+    function it_does_not_score_if_the_argument_is_not_a_string()
+    {
+        $this->scoreArgument(array('a substring', 'other value'))->shouldReturn(false);
+    }
+
     function its_string_representation_shows_substring()
     {
         $this->__toString()->shouldReturn('contains("a substring")');

--- a/src/Prophecy/Argument/Token/StringContainsToken.php
+++ b/src/Prophecy/Argument/Token/StringContainsToken.php
@@ -32,7 +32,7 @@ class StringContainsToken implements TokenInterface
 
     public function scoreArgument($argument)
     {
-        return strpos($argument, $this->value) !== false ? 6 : false;
+        return is_string($argument) && strpos($argument, $this->value) !== false ? 6 : false;
     }
 
     /**


### PR DESCRIPTION
I was trying to test a method from the Symphony console package used to print lines of text to the console https://symfony.com/doc/current/console/coloring.html

The method can take an array of strings or just a string, arrays of string are treated as multiple lines. 
The class I was trying to test used the method in both ways as in the following example : 

```
//this is called multiple times with different dynamic digits every time.
$output->writeln("Some output text and some dynamic number 982734");

$output->writeln([
    'foo',
    'bar'
])
```

In my unit test I wanted to do this 

```
$this->output->writeln(Argument::containingString("Some output text and some dynamic number"))->shouldBeCalled();
```

But I go the following error :

```
strpos() expects parameter 1 to be string, array given
```

This PR solves this issue but ensuring that the containing string token will only attempt to find the substring on the function argument if the argument itself is a string. If it's not a string, the token does not score.



