### PR TITLE
Introduce Argument::withAllEntries() and Argument::containingAllOf() helpers

### DIFF
--- a/spec/Prophecy/ArgumentSpec.php
+++ b/spec/Prophecy/ArgumentSpec.php
@@ -104,4 +104,16 @@ class ArgumentSpec extends ObjectBehavior
         $token = $this->approximate(10);
         $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\ApproximateValueToken');
     }
+
+    function it_has_a_shortcut_for_array_entries_have_all_values()
+    {
+        $token = $this->withAllEntries(array('key1' => 'value1', 'key2' => 'value2'));
+        $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\LogicalAndToken');
+    }
+
+    function it_has_a_shortcut_for_array_entries_have_all_key_value_pairs()
+    {
+        $token = $this->containingAllOf('value1', 'value2');
+        $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\LogicalAndToken');
+    }
 }

--- a/src/Prophecy/Argument.php
+++ b/src/Prophecy/Argument.php
@@ -209,4 +209,38 @@ class Argument
     {
         return new Token\ApproximateValueToken($value, $precision);
     }
+
+    /**
+     * Check that argument contains all (key, value) pairs
+     *
+     * @param mixed $values
+     *
+     * @return Token\LogicalAndToken
+     */
+    public static function withAllEntries($values)
+    {
+        $entries = array();
+        foreach ($values as $key => $value) {
+            $entries[] = new Token\ArrayEntryToken($key, $value);
+        }
+
+        return new Token\LogicalAndToken($entries);
+    }
+
+    /**
+     * Check that argument contains all of the values
+     *
+     * @param mixed ... a list of values
+     *
+     * @return Token\LogicalAndToken
+     */
+    public static function containingAllOf()
+    {
+        $entries = array();
+        foreach (func_get_args() as $value) {
+            $entries[] = new Token\ArrayEntryToken(self::any(), $value);
+        }
+
+        return new Token\LogicalAndToken($entries);
+    }
 }

--- a/tests/Argument/ArgumentTest.php
+++ b/tests/Argument/ArgumentTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Prophecy\Argument;
+
+use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
+
+class ArgumentTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_true_if_all_values_are_found_in_an_array()
+    {
+        $token = Argument::containingAllOf('a', 'b');
+
+        $this->assertSame(6.5, $token->scoreArgument(array('a', 'b', 'c')));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_false_if_a_value_is_missing_from_an_array()
+    {
+        $token = Argument::containingAllOf('b', 'c');
+
+        $this->assertFalse($token->scoreArgument(array('a', 'b', 'd')));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_true_if_all_pairs_are_found_in_an_array()
+    {
+        $token = Argument::withAllEntries(array('b' => 2, 'c' => 3));
+
+        $this->assertSame(8, $token->scoreArgument(array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4)));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_false_if_pair_is_missing_from_an_array()
+    {
+        $token = Argument::withAllEntries(array('b' => 2, 'c' => 3));
+
+        $this->assertFalse($token->scoreArgument(array('a' => 1, 'b' => 2, 'd')));
+    }
+}


### PR DESCRIPTION
Quite often seeing a need to check that array argument has a number of values or (key, value) pairs. Decided to put together two helper methods on the `Argument` class to help with these tasks:

```php
Argument::withAllEntries(['key' => 'value', 'foo' => 'bar']);
```
will match an array that has two specified (key, value) pairs: (`key`, `value`) and (`foo`, `bar`).

```php
Argument::containingAllOf('a', 'b', 'c');
```
will match an array that has all of the values specified as arguments.