### PR TITLE
Don't try to patch final constructors

### DIFF
--- a/spec/Prophecy/Doubler/ClassPatch/DisableConstructorPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/DisableConstructorPatchSpec.php
@@ -31,6 +31,7 @@ class DisableConstructorPatchSpec extends ObjectBehavior
         ArgumentNode $arg1,
         ArgumentNode $arg2
     ) {
+        $class->isExtendable('__construct')->willReturn(true);
         $class->hasMethod('__construct')->willReturn(true);
         $class->getMethod('__construct')->willReturn($method);
         $method->getArguments()->willReturn(array($arg1, $arg2));
@@ -45,9 +46,17 @@ class DisableConstructorPatchSpec extends ObjectBehavior
 
     function it_creates_new_constructor_if_object_has_none(ClassNode $class)
     {
+        $class->isExtendable('__construct')->willReturn(true);
         $class->hasMethod('__construct')->willReturn(false);
         $class->addMethod(Argument::type('Prophecy\Doubler\Generator\Node\MethodNode'))
             ->shouldBeCalled();
+
+        $this->apply($class);
+    }
+
+    function it_ignores_final_constructor(ClassNode $class)
+    {
+        $class->isExtendable('__construct')->willReturn(false);
 
         $this->apply($class);
     }

--- a/src/Prophecy/Doubler/ClassPatch/DisableConstructorPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/DisableConstructorPatch.php
@@ -41,6 +41,10 @@ class DisableConstructorPatch implements ClassPatchInterface
      */
     public function apply(ClassNode $node)
     {
+        if (!$node->isExtendable('__construct')) {
+            return;
+        }
+
         if (!$node->hasMethod('__construct')) {
             $node->addMethod(new MethodNode('__construct', ''));
 


### PR DESCRIPTION
According to #59, classes with final constructor are instantiated by the
Doubler using a doctrine Instantiator. However, the
DisableConstructorPatch tries to add a constructor to the class node,
even for final constructors, thus producing following error:

>  `__construct` is not extendable, so can not be added.

This fix just ignores final constructor in the DisableConstructorPatch.

Solves #295.