### PR TITLE
Allow `MethodProphecy::willThrow()` to accept Throwable as string

### DIFF
--- a/spec/Prophecy/Promise/ThrowPromiseSpec.php
+++ b/spec/Prophecy/Promise/ThrowPromiseSpec.php
@@ -84,6 +84,28 @@ class ThrowPromiseSpec extends ObjectBehavior
 
         $this->shouldNotThrow('Prophecy\Exception\InvalidArgumentException')->duringInstantiation();
     }
+
+    function it_throws_an_extension_of_throwable_by_class_name()
+    {
+        if (!interface_exists('\Throwable')) {
+            throw new SkippingException('The interface Throwable, introduced in PHP 7, does not exist');
+        }
+
+        $this->beConstructedWith('\Fixtures\Prophecy\ThrowableInterface');
+
+        $this->shouldNotThrow('Prophecy\Exception\InvalidArgumentException')->duringInstantiation();
+    }
+
+    function it_throws_a_throwable_by_class_name()
+    {
+        if (!interface_exists('\Throwable')) {
+            throw new SkippingException('The interface Throwable, introduced in PHP 7, does not exist');
+        }
+
+        $this->beConstructedWith('\Throwable');
+
+        $this->shouldNotThrow('Prophecy\Exception\InvalidArgumentException')->duringInstantiation();
+    }
 }
 
 class RequiredArgumentException extends \Exception

--- a/src/Prophecy/Promise/ThrowPromise.php
+++ b/src/Prophecy/Promise/ThrowPromise.php
@@ -41,7 +41,7 @@ class ThrowPromise implements PromiseInterface
     public function __construct($exception)
     {
         if (is_string($exception)) {
-            if (!class_exists($exception) || !$this->isAValidThrowable($exception)) {
+            if ((!class_exists($exception) && !interface_exists($exception)) || !$this->isAValidThrowable($exception)) {
                 throw new InvalidArgumentException(sprintf(
                     'Exception / Throwable class or instance expected as argument to ThrowPromise, but got %s.',
                     $exception
@@ -94,6 +94,7 @@ class ThrowPromise implements PromiseInterface
      */
     private function isAValidThrowable($exception)
     {
-        return is_a($exception, 'Exception', true) || is_subclass_of($exception, 'Throwable', true);
+        return is_a($exception, 'Exception', true)
+            || is_a($exception, 'Throwable', true);
     }
 }


### PR DESCRIPTION
- add additional check for existence of interface in contructor
- change `is_subclass_of` to `is_a` to allow for `Throwable` and subclasses of `Throwable`
- add specs for cases of `Throwable` and extensions of `Throwable`

To maintain support for php 5.3 the new specs are only applicable for PHP 7.0 and higher and `ThrowPromise::isValidThrowable()` checks for both `Exception` and `Throwable`.

fixes #428