### PR TITLE
Avoid using deprecated ReflectionType::__toString()

### DIFF
--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -143,8 +143,13 @@ class ClassMirror
             $node->setReturnsReference();
         }
 
-        if (version_compare(PHP_VERSION, '7.0', '>=') && $method->hasReturnType()) {
-            $returnType = (string) $method->getReturnType();
+        if (PHP_VERSION_ID >= 70000 && $method->hasReturnType()) {
+            if (PHP_VERSION_ID >= 70100) {
+                $returnType = $method->getReturnType()->getName();
+            } else {
+                $returnType = (string) $method->getReturnType();
+            }
+
             $returnTypeLower = strtolower($returnType);
 
             if ('self' === $returnTypeLower) {


### PR DESCRIPTION
Prophecy uses `ReflectionType::__toString()` which is [deprecated](https://www.php.net/manual/en/reflectiontype.tostring.php) since PHP 7.1. If used with PHPUnit, combined with Symfony `DeprecationErrorHandler`, it fails the test suite on PHP 7.4.0alpha1 (see [example](https://travis-ci.org/doctrine/dbal/jobs/545999926#L609)).