### PR TITLE
Add willYield feature to Method Prophecy

### DIFF
--- a/spec/Prophecy/Prophecy/MethodProphecySpec.php
+++ b/spec/Prophecy/Prophecy/MethodProphecySpec.php
@@ -143,6 +143,42 @@ class MethodProphecySpec extends ObjectBehavior
         $this->getPromise()->shouldBeAnInstanceOf('Prophecy\Promise\ReturnPromise');
     }
 
+    function it_adds_CallbackPromise_during_willYield_call(ObjectProphecy $objectProphecy)
+    {
+        if (PHP_VERSION_ID < 50500) {
+            throw new SkippingException('Yield language feature was introduced in >=5.5');
+        }
+
+        $objectProphecy->addMethodProphecy($this)->willReturn(null);
+
+        $this->willYield(array('foo', 'bar'));
+        $this->getPromise()->shouldBeAnInstanceOf('Prophecy\Promise\CallbackPromise');
+    }
+
+    function it_yields_elements_configured_in_willYield(ObjectProphecy $objectProphecy)
+    {
+        if (PHP_VERSION_ID < 70000) {
+            throw new SkippingException('Yield language feature was introduced in >=5.5 but shouldYield matcher only available in >=7.0');
+        }
+
+        $objectProphecy->addMethodProphecy($this)->willReturn(null);
+
+        $this->willYield(array('foo', 'bar'));
+        $this->getPromise()->execute(array(), $objectProphecy, $this)->shouldYield(array('foo', 'bar'));
+    }
+
+    function it_yields_key_value_paris_configured_in_willYield(ObjectProphecy $objectProphecy)
+    {
+        if (PHP_VERSION_ID < 70000) {
+            throw new SkippingException('Yield language feature was introduced in >=5.5 but shouldYield matcher only available in >=7.0');
+        }
+
+        $objectProphecy->addMethodProphecy($this)->willReturn(null);
+
+        $this->willYield(array(10 => 'foo', 11 => 'bar'));
+        $this->getPromise()->execute(array(), $objectProphecy, $this)->shouldYield(array(10 => 'foo', 11 => 'bar'));
+    }
+
     function it_adds_ThrowPromise_during_willThrow_call(ObjectProphecy $objectProphecy)
     {
         $objectProphecy->addMethodProphecy($this)->willReturn(null);

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -181,6 +181,40 @@ class MethodProphecy
     }
 
     /**
+     * @param array $items
+     *
+     * @return $this
+     *
+     * @throws \Prophecy\Exception\InvalidArgumentException
+     */
+    public function willYield($items)
+    {
+        if ($this->voidReturnType) {
+            throw new MethodProphecyException(
+                "The method \"$this->methodName\" has a void return type, and so cannot yield anything",
+                $this
+            );
+        }
+
+        if (!is_array($items)) {
+            throw new InvalidArgumentException(sprintf(
+                'Expected array, but got %s.',
+                gettype($items)
+            ));
+        }
+
+        // Remove eval() when minimum version >=5.5
+        /** @var callable $generator */
+        $generator = eval('return function() use ($items) {
+            foreach ($items as $key => $value) {
+                yield $key => $value;
+            }
+        };');
+
+        return $this->will($generator);
+    }
+
+    /**
      * Sets return argument promise to the prophecy.
      *
      * @param int $index The zero-indexed number of the argument to return


### PR DESCRIPTION
Adds `willYield` functionality. Usage:
```
function it_should_do_something(MyCollaborator $myCollaborator) {
    // arrange
    $myCollaborator->generate()->willYield(['foo', 'bar']);
    $this->beConstructedWith($myCollaborator);

    // act
    $result = $this->doSomething();

    // assert
    $result->shouldBe('foo/bar');
}
```

Depends on https://github.com/phpspec/prophecy/pull/434 (will rebase this PR once the other one merged)