### PR TITLE
Fix broken build for PHP 5.4 and PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,12 @@ branches:
 
 matrix:
   include:
+    - php: 5.3
+      dist: precise
     - php: 5.4
+      dist: trusty
     - php: 5.5
+      dist: trusty
     - php: 5.6
       env: DEPENDENCIES='low'
     - php: 5.6
@@ -24,11 +28,7 @@ matrix:
     - php: 7.2
     - php: 7.3
     - php: 7.4snapshot
-    - php: 5.3
-      dist: precise
   fast_finish: true
-  allow_failures:
-    - php: 7.4snapshot
 
 install:
   - export COMPOSER_ROOT_VERSION=dev-master


### PR DESCRIPTION
These versions aren't available in the xenial build environment.