### PR TITLE
Fix issue #120 by delaying unexpected method call evaluation

### DIFF
--- a/spec/Prophecy/Prophecy/MethodProphecySpec.php
+++ b/spec/Prophecy/Prophecy/MethodProphecySpec.php
@@ -330,7 +330,7 @@ class MethodProphecySpec extends ObjectBehavior
         $this->withArguments($arguments);
 
         try {
-          $this->callOnWrappedObject('shouldHave', array($prediction));
+            $this->callOnWrappedObject('shouldHave', array($prediction));
         } catch (\Exception $e) {}
 
         $this->getCheckedPredictions()->shouldReturn(array($prediction));
@@ -342,6 +342,7 @@ class MethodProphecySpec extends ObjectBehavior
         Call $call1,
         Call $call2
     ) {
+        $objectProphecy->addMethodProphecy($this)->willReturn(null);
         $callback = function ($calls, $object, $method) {
             throw new RuntimeException;
         };

--- a/spec/Prophecy/Prophecy/ObjectProphecySpec.php
+++ b/spec/Prophecy/Prophecy/ObjectProphecySpec.php
@@ -264,6 +264,17 @@ class ObjectProphecySpec extends ObjectBehavior
 
         $methodProphecy2->shouldNotBe($methodProphecy1);
     }
+
+    function it_throws_UnexpectedCallException_during_checkPredictions_if_unexpected_method_was_called(
+        $lazyDouble, CallCenter $callCenter
+    ) {
+        $this->beConstructedWith($lazyDouble, $callCenter);
+
+        $callCenter->checkUnexpectedCalls()->willThrow('Prophecy\Exception\Call\UnexpectedCallException');
+
+        $this->shouldThrow('Prophecy\Exception\Call\UnexpectedCallException')
+             ->duringCheckProphecyMethodsPredictions();
+    }
 }
 
 class ObjectProphecySpecFixtureA

--- a/src/Prophecy/Call/CallCenter.php
+++ b/src/Prophecy/Call/CallCenter.php
@@ -17,6 +17,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\Argument\ArgumentsWildcard;
 use Prophecy\Util\StringUtil;
 use Prophecy\Exception\Call\UnexpectedCallException;
+use SplObjectStorage;
 
 /**
  * Calls receiver & manager.
@@ -33,6 +34,11 @@ class CallCenter
     private $recordedCalls = array();
 
     /**
+     * @var SplObjectStorage
+     */
+    private $unexpectedCalls;
+
+    /**
      * Initializes call center.
      *
      * @param StringUtil $util
@@ -40,6 +46,7 @@ class CallCenter
     public function __construct(StringUtil $util = null)
     {
         $this->util = $util ?: new StringUtil;
+        $this->unexpectedCalls = new SplObjectStorage();
     }
 
     /**
@@ -81,16 +88,14 @@ class CallCenter
         }
 
         // There are method prophecies, so it's a fake/stub. Searching prophecy for this call
-        $matches = array();
-        foreach ($prophecy->getMethodProphecies($methodName) as $methodProphecy) {
-            if (0 < $score = $methodProphecy->getArgumentsWildcard()->scoreArguments($arguments)) {
-                $matches[] = array($score, $methodProphecy);
-            }
-        }
+        $matches = $this->findMethodProphecies($prophecy, $methodName, $arguments);
 
         // If fake/stub doesn't have method prophecy for this call - throw exception
         if (!count($matches)) {
-            throw $this->createUnexpectedCallException($prophecy, $methodName, $arguments);
+            $this->unexpectedCalls->attach(new Call($methodName, $arguments, null, null, $file, $line), $prophecy);
+            $this->recordedCalls[] = new Call($methodName, $arguments, null, null, $file, $line);
+
+            return null;
         }
 
         // Sort matches by their score value
@@ -145,6 +150,22 @@ class CallCenter
                 ;
             })
         );
+    }
+
+    /**
+     * @throws UnexpectedCallException
+     */
+    public function checkUnexpectedCalls()
+    {
+        /** @var Call $call */
+        foreach ($this->unexpectedCalls as $call) {
+            $prophecy = $this->unexpectedCalls[$call];
+
+            // If fake/stub doesn't have method prophecy for this call - throw exception
+            if (!count($this->findMethodProphecies($prophecy, $call->getMethodName(), $call->getArguments()))) {
+                throw $this->createUnexpectedCallException($prophecy, $call->getMethodName(), $call->getArguments());
+            }
+        }
     }
 
     private function createUnexpectedCallException(ObjectProphecy $prophecy, $methodName,
@@ -225,5 +246,24 @@ class CallCenter
             },
             $arguments
         );
+    }
+
+    /**
+     * @param ObjectProphecy $prophecy
+     * @param string $methodName
+     * @param array $arguments
+     *
+     * @return array
+     */
+    private function findMethodProphecies(ObjectProphecy $prophecy, $methodName, array $arguments)
+    {
+        $matches = array();
+        foreach ($prophecy->getMethodProphecies($methodName) as $methodProphecy) {
+            if (0 < $score = $methodProphecy->getArgumentsWildcard()->scoreArguments($arguments)) {
+                $matches[] = array($score, $methodProphecy);
+            }
+        }
+
+        return $matches;
     }
 }

--- a/src/Prophecy/Prophecy/ObjectProphecy.php
+++ b/src/Prophecy/Prophecy/ObjectProphecy.php
@@ -208,11 +208,14 @@ class ObjectProphecy implements ProphecyInterface
      * Checks that registered method predictions do not fail.
      *
      * @throws \Prophecy\Exception\Prediction\AggregateException If any of registered predictions fail
+     * @throws \Prophecy\Exception\Call\UnexpectedCallException
      */
     public function checkProphecyMethodsPredictions()
     {
         $exception = new AggregateException(sprintf("%s:\n", get_class($this->reveal())));
         $exception->setObjectProphecy($this);
+
+        $this->callCenter->checkUnexpectedCalls();
 
         foreach ($this->methodProphecies as $prophecies) {
             foreach ($prophecies as $prophecy) {


### PR DESCRIPTION
This PR fixes the bug #120.

## The problem

Unexpected method call check is happening immediately after the method called on the test subject. This check is not aware of the method prophecies (expected method calls) defined by spies (shouldHaveBeenCalled). Therefor it throws an exception, but it shouldn't.

Given the following specification and implementation, PHPSpec reports an error, but it shouldn't.
### Specification
```php
class SpiesExampleSpec extends ObjectBehavior
{
    function it_does_not_expect_spied_on_methods(\DateTime $time)
    {
        $time->getOffset()->willReturn(-1800);

        $this->modifyTimestamp($time);

        $time->setTimestamp(1234)->shouldHaveBeenCalled();
    }
}
```

### Implementation
```php
class SpiesExample
{
    public function modifyTimestamp(\DateTime $time)
    {
        $time->getOffset();
        $time->setTimestamp(1234);
    }
}
```

### Output
```
  10  ! it does not expect spies
      method call:
        Double\DateTime\P1->setTimestamp(1234)
      was not expected.
      Expected calls are:
        - getOffset()
```

## The solution

Instead of throwing the exception, the unexpected method calls are recorded, and they are checked again after an example is executed. At this point all spies have registered their method prophecies, so we can identify the correct list of unexpected method calls.

## Consequences

The order of reported error types has changed.

Before
- Unexpected method calls (any method call without return promise)
- Spies (e.g. shouldHaveBeenCalled)
- Other predictions (e.g. shouldBeCalled)

After
- Spies (e.g. shouldHaveBeenCalled)
- Unexpected method calls (any method call without return promise)
- Other predictions (e.g. shouldBeCalled)

To make the order unchanged, it would be possible to delay the evaluation of spy predictions in a similar way how it's done with unexpected method calls. 

Also currently the "other predictions" check raises an `AggregateException` with all the failed predictions. By delaying spy prediction checks, we could aggregate all failed predictions into one `AggregateException`.
