### PR TITLE
Hotfix: case insensitive methods

### DIFF
--- a/spec/Prophecy/Prophecy/ObjectProphecySpec.php
+++ b/spec/Prophecy/Prophecy/ObjectProphecySpec.php
@@ -125,7 +125,7 @@ class ObjectProphecySpec extends ObjectBehavior
         $this->addMethodProphecy($methodProphecy);
 
         $this->getMethodProphecies()->shouldReturn(array(
-            'getUsername' => array($methodProphecy)
+            'getusername' => array($methodProphecy)
         ));
     }
 
@@ -145,7 +145,30 @@ class ObjectProphecySpec extends ObjectBehavior
         $this->addMethodProphecy($methodProphecy2);
 
         $this->getMethodProphecies()->shouldReturn(array(
-            'getUsername' => array(
+            'getusername' => array(
+                $methodProphecy1,
+                $methodProphecy2,
+            )
+        ));
+    }
+
+    function its_addMethodProphecy_handles_prophecies_for_caseinsensitive_method_names(
+        MethodProphecy $methodProphecy1,
+        MethodProphecy $methodProphecy2,
+        ArgumentsWildcard $argumentsWildcard1,
+        ArgumentsWildcard $argumentsWildcard2
+    ) {
+        $methodProphecy1->getArgumentsWildcard()->willReturn($argumentsWildcard1);
+        $methodProphecy1->getMethodName()->willReturn('getUsername');
+
+        $methodProphecy2->getArgumentsWildcard()->willReturn($argumentsWildcard2);
+        $methodProphecy2->getMethodName()->willReturn('getUserName');
+
+        $this->addMethodProphecy($methodProphecy1);
+        $this->addMethodProphecy($methodProphecy2);
+
+        $this->getMethodProphecies()->shouldReturn(array(
+            'getusername' => array(
                 $methodProphecy1,
                 $methodProphecy2,
             )
@@ -168,10 +191,10 @@ class ObjectProphecySpec extends ObjectBehavior
         $this->addMethodProphecy($methodProphecy2);
 
         $this->getMethodProphecies()->shouldReturn(array(
-            'getUsername' => array(
+            'getusername' => array(
                 $methodProphecy1
             ),
-            'isUsername' => array(
+            'isusername' => array(
                 $methodProphecy2
             )
         ));

--- a/src/Prophecy/Call/CallCenter.php
+++ b/src/Prophecy/Call/CallCenter.php
@@ -138,11 +138,11 @@ class CallCenter
      */
     public function findCalls($methodName, ArgumentsWildcard $wildcard)
     {
-        $lowerMethodName = strtolower($methodName);
+        $methodName = strtolower($methodName);
 
         return array_values(
-            array_filter($this->recordedCalls, function (Call $call) use ($lowerMethodName, $wildcard) {
-                return $lowerMethodName === strtolower($call->getMethodName())
+            array_filter($this->recordedCalls, function (Call $call) use ($methodName, $wildcard) {
+                return $methodName === strtolower($call->getMethodName())
                     && 0 < $call->getScore($wildcard)
                 ;
             })

--- a/src/Prophecy/Call/CallCenter.php
+++ b/src/Prophecy/Call/CallCenter.php
@@ -74,7 +74,7 @@ class CallCenter
         }
 
         // If no method prophecies defined, then it's a dummy, so we'll just return null
-        if ('__destruct' === $methodName || 0 == count($prophecy->getMethodProphecies())) {
+        if ('__destruct' === strtolower($methodName) || 0 == count($prophecy->getMethodProphecies())) {
             $this->recordedCalls[] = new Call($methodName, $arguments, null, null, $file, $line);
 
             return null;
@@ -138,9 +138,11 @@ class CallCenter
      */
     public function findCalls($methodName, ArgumentsWildcard $wildcard)
     {
+        $lowerMethodName = strtolower($methodName);
+
         return array_values(
-            array_filter($this->recordedCalls, function (Call $call) use ($methodName, $wildcard) {
-                return $methodName === $call->getMethodName()
+            array_filter($this->recordedCalls, function (Call $call) use ($lowerMethodName, $wildcard) {
+                return $lowerMethodName === strtolower($call->getMethodName())
                     && 0 < $call->getScore($wildcard)
                 ;
             })

--- a/src/Prophecy/Prophecy/ObjectProphecy.php
+++ b/src/Prophecy/Prophecy/ObjectProphecy.php
@@ -146,7 +146,7 @@ class ObjectProphecy implements ProphecyInterface
             ), $methodProphecy);
         }
 
-        $methodName = $methodProphecy->getMethodName();
+        $methodName = strtolower($methodProphecy->getMethodName());
 
         if (!isset($this->methodProphecies[$methodName])) {
             $this->methodProphecies[$methodName] = array();
@@ -168,18 +168,13 @@ class ObjectProphecy implements ProphecyInterface
             return $this->methodProphecies;
         }
 
-        $lowerMethodName = strtolower($methodName);
+        $methodName = strtolower($methodName);
 
-        $result = array();
-        foreach ($this->methodProphecies as $name => $prophecies) {
-            if (strtolower($name) === $lowerMethodName) {
-                foreach ($prophecies as $prophecy) {
-                    $result[] = $prophecy;
-                }
-            }
+        if (!isset($this->methodProphecies[$methodName])) {
+            return array();
         }
 
-        return $result;
+        return $this->methodProphecies[$methodName];
     }
 
     /**

--- a/src/Prophecy/Prophecy/ObjectProphecy.php
+++ b/src/Prophecy/Prophecy/ObjectProphecy.php
@@ -168,11 +168,18 @@ class ObjectProphecy implements ProphecyInterface
             return $this->methodProphecies;
         }
 
-        if (!isset($this->methodProphecies[$methodName])) {
-            return array();
+        $lowerMethodName = strtolower($methodName);
+
+        $result = array();
+        foreach ($this->methodProphecies as $name => $prophecies) {
+            if (strtolower($name) === $lowerMethodName) {
+                foreach ($prophecies as $prophecy) {
+                    $result[] = $prophecy;
+                }
+            }
         }
 
-        return $this->methodProphecies[$methodName];
+        return $result;
     }
 
     /**

--- a/tests/Doubler/Generator/ClassMirrorTest.php
+++ b/tests/Doubler/Generator/ClassMirrorTest.php
@@ -498,4 +498,20 @@ class ClassMirrorTest extends TestCase
 
         $this->assertEquals('__dot_dot_dot__', $argumentNode->getName());
     }
+
+    /**
+     * @test
+     */
+    public function case_insensitive_method_names()
+    {
+        $prophecy = $this->prophesize('ArrayObject');
+        $prophecy->offsetGet(1)->willReturn(1)->shouldBeCalledTimes(1);
+        $prophecy->offsetget(2)->willReturn(2)->shouldBeCalledTimes(1);
+        $prophecy->OffsetGet(3)->willReturn(3)->shouldBeCalledTimes(1);
+
+        $arrayObject = $prophecy->reveal();
+        self::assertSame(1, $arrayObject->offsetGet(1));
+        self::assertSame(2, $arrayObject->offsetGet(2));
+        self::assertSame(3, $arrayObject->offsetGet(3));
+    }
 }


### PR DESCRIPTION
Fixes #165

Prophecy was case sensitive for methods, but PHP is not.

Because of that we have an issue in https://github.com/zendframework/zend-expressive-swoole/pull/70 as method name in the extension has been changed from `rawcontent` to `rawContent`.