### PR TITLE
Fix nesting error when comparing objects

### DIFF
--- a/src/Prophecy/Argument/Token/ExactValueToken.php
+++ b/src/Prophecy/Argument/Token/ExactValueToken.php
@@ -59,7 +59,9 @@ class ExactValueToken implements TokenInterface
             try {
                 $comparator->assertEquals($argument, $this->value);
                 return 10;
-            } catch (ComparisonFailure $failure) {}
+            } catch (ComparisonFailure $failure) {
+            	return false;
+			}
         }
 
         // If either one is an object it should be castable to a string

--- a/tests/Argument/Token/ExactValueTokenTest.php
+++ b/tests/Argument/Token/ExactValueTokenTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Prophecy\Argument\Token;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument\Token\ExactValueToken;
+
+class ExactValueTokenTest extends TestCase {
+	/**
+	 * @test
+	 * @see https://github.com/phpspec/prophecy/issues/268
+	 * @see https://stackoverflow.com/a/19097159/2424814
+	 */
+	public function does_not_trigger_nesting_error() {
+		$child1 = new ChildClass('A', new ParentClass());
+		$child2 = new ChildClass('B', new ParentClass());
+
+		$exactValueToken = new ExactValueToken($child1);
+		self::assertEquals(false, $exactValueToken->scoreArgument($child2));
+	}
+
+	/**
+	 * @test
+	 */
+	public function scores_10_for_objects_with_same_fields() {
+		$child1 = new ChildClass('A', new ParentClass());
+		$child2 = new ChildClass('A', new ParentClass());
+
+		$exactValueToken = new ExactValueToken($child1);
+		self::assertEquals(10, $exactValueToken->scoreArgument($child2));
+	}
+
+	/**
+	 * @test
+	 */
+	public function scores_false_for_object_and_string() {
+		$child1 = new ChildClass('A', new ParentClass());
+
+		$exactValueToken = new ExactValueToken($child1);
+		self::assertEquals(false, $exactValueToken->scoreArgument("A"));
+	}
+
+	/**
+	 * @test
+	 */
+	public function scores_false_for_object_and_int() {
+		$child1 = new ChildClass('A', new ParentClass());
+
+		$exactValueToken = new ExactValueToken($child1);
+		self::assertEquals(false, $exactValueToken->scoreArgument(100));
+	}
+
+	/**
+	 * @test
+	 */
+	public function scores_false_for_object_and_stdclass() {
+		$child1 = new ChildClass('A', new ParentClass());
+
+		$exactValueToken = new ExactValueToken($child1);
+		self::assertEquals(false, $exactValueToken->scoreArgument(new \stdClass()));
+	}
+
+	/**
+	 * @test
+	 */
+	public function scores_false_for_object_and_null() {
+		$child1 = new ChildClass('A', new ParentClass());
+
+		$exactValueToken = new ExactValueToken($child1);
+		self::assertEquals(false, $exactValueToken->scoreArgument(null));
+	}
+
+}
+
+
+class ParentClass {
+
+	public $children = [];
+
+	public function addChild(ChildClass $child) {
+		$this->children[] = $child;
+	}
+}
+
+class ChildClass {
+
+	public $parent = null;
+	public $name = null;
+
+	public function __construct(string $name, ParentClass $parent) {
+		$this->name = $name;
+		$this->parent = $parent;
+		$this->parent->addChild($this);
+	}
+
+}

--- a/tests/Argument/Token/ExactValueTokenTest.php
+++ b/tests/Argument/Token/ExactValueTokenTest.php
@@ -75,9 +75,9 @@ class ExactValueTokenTest extends TestCase {
 
 class ParentClass {
 
-	public $children = [];
+	public $children = array();
 
-	public function addChild(ChildClass $child) {
+	public function addChild($child) {
 		$this->children[] = $child;
 	}
 }
@@ -87,7 +87,7 @@ class ChildClass {
 	public $parent = null;
 	public $name = null;
 
-	public function __construct(string $name, ParentClass $parent) {
+	public function __construct($name, $parent) {
 		$this->name = $name;
 		$this->parent = $parent;
 		$this->parent->addChild($this);


### PR DESCRIPTION
When mocking method calls with complex objects (doctrine entities) I got PHP errors today: "PHP Fatal error:  Nesting level too deep - recursive dependency?"

This issue has already been discussed here: https://github.com/phpspec/prophecy/issues/268

The problem lies in the class method `ExactValueToken#scoreArgument`
When the ObjectComparator throws a `ComparisonFailure ` this method just ignores it - I don't see why because the phpunit comparator works quite well and seems to already cover recursion.

`ExactValueToken` then goes on and tries to compare the 2 objects with `$argument == $this->value` which causes a PHP internal nesting error - see also: https://stackoverflow.com/a/19097159/2424814

I've fixed this and added some tests.