### PR TITLE
Compare callables as an exact match if they are identical

### DIFF
--- a/spec/Prophecy/Comparator/ClosureComparatorSpec.php
+++ b/spec/Prophecy/Comparator/ClosureComparatorSpec.php
@@ -25,15 +25,15 @@ class ClosureComparatorSpec extends ObjectBehavior
         $this->accepts(function(){}, function(){})->shouldReturn(true);
     }
 
-    function it_asserts_that_all_closures_are_different()
+    function it_asserts_that_different_closures_are_different()
     {
         $this->shouldThrow()->duringAssertEquals(function(){}, function(){});
     }
 
-    function it_asserts_that_all_closures_are_different_even_if_its_the_same_closure()
+    function it_asserts_that_closures_are_equal_if_its_the_same_closure()
     {
         $closure = function(){};
 
-        $this->shouldThrow()->duringAssertEquals($closure, $closure);
+        $this->shouldNotThrow()->duringAssertEquals($closure, $closure);
     }
 }

--- a/src/Prophecy/Comparator/ClosureComparator.php
+++ b/src/Prophecy/Comparator/ClosureComparator.php
@@ -29,14 +29,16 @@ final class ClosureComparator extends Comparator
 
     public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false, array &$processed = array())
     {
-        throw new ComparisonFailure(
-            $expected,
-            $actual,
-            // we don't need a diff
-            '',
-            '',
-            false,
-            'all closures are born different'
-        );
+        if ($expected !== $actual) {
+            throw new ComparisonFailure(
+                $expected,
+                $actual,
+                // we don't need a diff
+                '',
+                '',
+                false,
+                'all closures are different if not identical'
+            );
+        }
     }
 }

--- a/tests/Argument/Token/ExactValueTokenTest.php
+++ b/tests/Argument/Token/ExactValueTokenTest.php
@@ -30,6 +30,16 @@ class ExactValueTokenTest extends TestCase {
 		self::assertEquals(10, $exactValueToken->scoreArgument($child2));
 	}
 
+    /**
+     * @test
+     */
+    public function scores_10_for_matching_callables() {
+        $callable = function() {};
+
+        $exactValueToken = new ExactValueToken($callable);
+        self::assertEquals(10, $exactValueToken->scoreArgument($callable));
+    }
+
 	/**
 	 * @test
 	 */
@@ -69,7 +79,6 @@ class ExactValueTokenTest extends TestCase {
 		$exactValueToken = new ExactValueToken($child1);
 		self::assertEquals(false, $exactValueToken->scoreArgument(null));
 	}
-
 }
 
 


### PR DESCRIPTION
Our comparator has always treated callables as not-equal in all cases, however before #446 that error was swallowed and we fell back to other comparison methods.

This fixes #458 by making Closures match when they're identical

It will still be best practice to match on something like `Argument::is()`