### PR TITLE
Add Argument::in() and Argument::notIn()

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ That's why Prophecy comes bundled with a bunch of other tokens:
 - `AnyValueToken` or `Argument::any()` - matches any argument
 - `AnyValuesToken` or `Argument::cetera()` - matches any arguments to the rest of the signature
 - `StringContainsToken` or `Argument::containingString($value)` - checks that the argument contains a specific string value
+- `InArrayToken` or `Argument::in($array)` - checks if value is in array
 
 And you can add even more by implementing `TokenInterface` with your own custom classes.
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ That's why Prophecy comes bundled with a bunch of other tokens:
 - `AnyValuesToken` or `Argument::cetera()` - matches any arguments to the rest of the signature
 - `StringContainsToken` or `Argument::containingString($value)` - checks that the argument contains a specific string value
 - `InArrayToken` or `Argument::in($array)` - checks if value is in array
+- `NotInArrayToken` or `Argument::notIn($array)` - checks if value is not in array
 
 And you can add even more by implementing `TokenInterface` with your own custom classes.
 

--- a/spec/Prophecy/Argument/Token/InArrayTokenSpec.php
+++ b/spec/Prophecy/Argument/Token/InArrayTokenSpec.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace spec\Prophecy\Argument\Token;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument\Token\TokenInterface;
+
+class InArrayTokenSpec extends ObjectBehavior
+{
+    function it_implements_TokenInterface()
+    {
+        $this->beConstructedWith(array());
+        $this->shouldBeAnInstanceOf('Prophecy\Argument\Token\TokenInterface');
+    }
+
+    function it_is_not_last()
+    {
+        $this->beConstructedWith(array());
+        $this->shouldNotBeLast();
+    }
+
+    function it_scores_8_if_argument_is_in_array()
+    {
+        $this->beConstructedWith(array(1, 2, 3));
+        $this->scoreArgument(2)->shouldReturn(8);
+    }
+
+    function it_scores_false_if_argument_is_not_in_array()
+    {
+        $this->beConstructedWith(array(1, 2, 3));
+        $this->scoreArgument(5)->shouldReturn(false);
+    }
+
+    function it_generates_array_in_string_format()
+    {
+        $this->beConstructedWith(array(1, 2, 3));
+        $this->__toString()->shouldBe('[1, 2, 3]');
+    }
+
+    function it_generates_an_empty_array_as_string_when_token_is_empty()
+    {
+        $this->beConstructedWith(array());
+        $this->__toString()->shouldBe('[]');
+    }
+}

--- a/spec/Prophecy/Argument/Token/NotInArrayTokenSpec.php
+++ b/spec/Prophecy/Argument/Token/NotInArrayTokenSpec.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace spec\Prophecy\Argument\Token;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument\Token\TokenInterface;
+
+class NotInArrayTokenSpec extends ObjectBehavior
+{
+    function it_implements_TokenInterface()
+    {
+        $this->beConstructedWith(array());
+        $this->shouldBeAnInstanceOf('Prophecy\Argument\Token\TokenInterface');
+    }
+
+    function it_is_not_last()
+    {
+        $this->beConstructedWith(array());
+        $this->shouldNotBeLast();
+    }
+
+    function it_scores_8_if_argument_is_not_in_array()
+    {
+        $this->beConstructedWith(array(1, 2, 3));
+        $this->scoreArgument(5)->shouldReturn(8);
+    }
+
+    function it_scores_false_if_argument_is_in_array()
+    {
+        $this->beConstructedWith(array(1, 2, 3));
+        $this->scoreArgument(2)->shouldReturn(false);
+    }
+
+    function it_generates_array_in_string_format()
+    {
+        $this->beConstructedWith(array(1, 2, 3));
+        $this->__toString()->shouldBe('[1, 2, 3]');
+    }
+
+    function it_generates_an_empty_array_as_string_when_token_is_empty()
+    {
+        $this->beConstructedWith(array());
+        $this->__toString()->shouldBe('[]');
+    }
+}

--- a/spec/Prophecy/ArgumentSpec.php
+++ b/spec/Prophecy/ArgumentSpec.php
@@ -110,4 +110,10 @@ class ArgumentSpec extends ObjectBehavior
         $token = $this->in(array(1, 2, 3));
         $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\InArrayToken');
     }
+
+    function it_has_a_shortcut_for_not_in_token()
+    {
+        $token = $this->notIn(array(1, 2, 3));
+        $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\NotInArrayToken');
+    }
 }

--- a/spec/Prophecy/ArgumentSpec.php
+++ b/spec/Prophecy/ArgumentSpec.php
@@ -104,4 +104,10 @@ class ArgumentSpec extends ObjectBehavior
         $token = $this->approximate(10);
         $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\ApproximateValueToken');
     }
+
+    function it_has_a_shortcut_for_in_token()
+    {
+        $token = $this->in(array(1, 2, 3));
+        $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\InArrayToken');
+    }
 }

--- a/src/Prophecy/Argument.php
+++ b/src/Prophecy/Argument.php
@@ -209,4 +209,17 @@ class Argument
     {
         return new Token\ApproximateValueToken($value, $precision);
     }
+
+    /**
+     * Checks that argument is in array.
+     *
+     * @param array $value
+     *
+     * @return Token\InArrayToken
+     */
+
+    public function in($value)
+    {
+        return new Token\InArrayToken($value);
+    }
 }

--- a/src/Prophecy/Argument.php
+++ b/src/Prophecy/Argument.php
@@ -222,4 +222,18 @@ class Argument
     {
         return new Token\InArrayToken($value);
     }
+
+    /**
+     * Checks that argument is in array.
+     *
+     * @param array $value
+     *
+     * @return Token\InArrayToken
+     */
+
+    public function notIn($value)
+    {
+        return new Token\NotInArrayToken($value);
+    }
+
 }

--- a/src/Prophecy/Argument/Token/InArrayToken.php
+++ b/src/Prophecy/Argument/Token/InArrayToken.php
@@ -19,13 +19,16 @@ namespace Prophecy\Argument\Token;
 class InArrayToken implements TokenInterface
 {
     private $token = array();
+    private $strict;
 
     /**
      * @param array $arguments tokens
+     * @param bool $strict
      */
-    public function __construct(array $arguments)
+    public function __construct(array $arguments, $strict = true)
     {
         $this->token = $arguments;
+        $this->strict = $strict;
     }
 
     /**
@@ -41,7 +44,7 @@ class InArrayToken implements TokenInterface
             return false;
         }
 
-        if (in_array($argument, $this->token)) {
+        if (\in_array($argument, $this->token, $this->strict)) {
             return 8;
         }
 

--- a/src/Prophecy/Argument/Token/InArrayToken.php
+++ b/src/Prophecy/Argument/Token/InArrayToken.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Prophecy\Argument\Token;
+
+/**
+ * Check if values is in array
+ *
+ * @author Vinícius Alonso <vba321@hotmail.com>
+ */
+class InArrayToken implements TokenInterface
+{
+    private $token = array();
+
+    /**
+     * @param array $arguments tokens
+     */
+    public function __construct(array $arguments)
+    {
+        $this->token = $arguments;
+    }
+
+    /**
+     * Return scores 8 score if argument is in array.
+     *
+     * @param $argument
+     *
+     * @return bool|int
+     */
+    public function scoreArgument($argument)
+    {
+        if (count($this->token) === 0) {
+            return false;
+        }
+
+        if (in_array($argument, $this->token)) {
+            return 8;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns false.
+     *
+     * @return boolean
+     */
+    public function isLast()
+    {
+        return false;
+    }
+
+    /**
+     * Returns string representation for token.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $arrayAsString = implode(', ', $this->token);
+        return "[{$arrayAsString}]";
+    }
+}

--- a/src/Prophecy/Argument/Token/NotInArrayToken.php
+++ b/src/Prophecy/Argument/Token/NotInArrayToken.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Prophecy.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *     Marcello Duarte <marcello.duarte@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Prophecy\Argument\Token;
+
+/**
+ * Check if values is not in array
+ *
+ * @author Vinícius Alonso <vba321@hotmail.com>
+ */
+class NotInArrayToken implements TokenInterface
+{
+    private $token = array();
+
+    /**
+     * @param array $arguments tokens
+     */
+    public function __construct(array $arguments)
+    {
+        $this->token = $arguments;
+    }
+
+    /**
+     * Return scores 8 score if argument is in array.
+     *
+     * @param $argument
+     *
+     * @return bool|int
+     */
+    public function scoreArgument($argument)
+    {
+        if (count($this->token) === 0) {
+            return false;
+        }
+
+        if (!in_array($argument, $this->token)) {
+            return 8;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns false.
+     *
+     * @return boolean
+     */
+    public function isLast()
+    {
+        return false;
+    }
+
+    /**
+     * Returns string representation for token.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $arrayAsString = implode(', ', $this->token);
+        return "[{$arrayAsString}]";
+    }
+}
+

--- a/src/Prophecy/Argument/Token/NotInArrayToken.php
+++ b/src/Prophecy/Argument/Token/NotInArrayToken.php
@@ -19,13 +19,16 @@ namespace Prophecy\Argument\Token;
 class NotInArrayToken implements TokenInterface
 {
     private $token = array();
+    private $strict;
 
     /**
      * @param array $arguments tokens
+     * @param bool $strict
      */
-    public function __construct(array $arguments)
+    public function __construct(array $arguments, $strict = true)
     {
         $this->token = $arguments;
+        $this->strict = $strict;
     }
 
     /**
@@ -41,7 +44,7 @@ class NotInArrayToken implements TokenInterface
             return false;
         }
 
-        if (!in_array($argument, $this->token)) {
+        if (!\in_array($argument, $this->token, $this->strict)) {
             return 8;
         }
 


### PR DESCRIPTION
I was working in some exercises using TDD and I needed to write an example like this:

```php
$rule = $this->prophesize(MultipleThreeRule::class);
                                                                        
$rule->condition(Argument::that(function($arg) {
    return in_array($arg, [3, 6, 9, 12]);
}))->willReturn(true);
```
The idea is guarantee that a value is in array.

```php
$rule->condition(12); // returns true
``` 
Then, I implemented an easier way to get to same result:

```php
$rule = $this->prophesize(MultipleThreeRule::class);
                                                                        
$rule->condition(Argument::in([3, 6, 9, 12]))->willReturn(true);
```

And I also I implemented the opposite way, when value is not in array:

```php
$rule = $this->prophesize(MultipleThreeRule::class);
                                                                        
$rule->condition(Argument::notIn([3, 6, 9, 12]))->willReturn(false);
```