### PR TITLE
Make this compatible with next versions of sebastian/comparator and sebastian/recursion-context

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     "require": {
         "php":                               "^5.3|^7.0",
         "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-        "sebastian/comparator":              "^1.2.3|^2.0|^3.0",
+        "sebastian/comparator":              "^1.2.3|^2.0|^3.0|^4.0",
         "doctrine/instantiator":             "^1.0.2",
-        "sebastian/recursion-context":       "^1.0|^2.0|^3.0"
+        "sebastian/recursion-context":       "^1.0|^2.0|^3.0|^4.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
The new versions will be released on February 7 and will be 100% compatible. In fact, there will likely not be any code changes. I am merely bumping the major version because of dropped support for PHP < 7.3.