### PR TITLE
Fix methods signatures issue with sebastian/comparator

### DIFF
--- a/src/Prophecy/Comparator/ClosureComparator.php
+++ b/src/Prophecy/Comparator/ClosureComparator.php
@@ -27,7 +27,7 @@ final class ClosureComparator extends Comparator
             && is_object($actual) && $actual instanceof \Closure;
     }
 
-    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false, array &$processed = array())
+    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false, array &$processed = array()): void
     {
         if ($expected !== $actual) {
             throw new ComparisonFailure(


### PR DESCRIPTION
Had the following issue on the checks of this PR: https://github.com/KnpLabs/KnpMenuBundle/pull/424

PHP Fatal error: Declaration of Prophecy\Comparator\ProphecyComparator::assertEquals($expected, $actual, $delta = 0, $canonicalize = false, $ignoreCase = false, array &$processed = Array) must be compatible with SebastianBergmann\Comparator\ObjectComparator::assertEquals($expected, $actual, $delta = 0, $canonicalize = false, $ignoreCase = false, array &$processed = Array): void in /home/travis/build/KnpLabs/KnpMenuBundle/vendor/phpspec/prophecy/src/Prophecy/Comparator/ProphecyComparator.php on line 24

I updated the method signature to match with `SebastianBergmann\Comparator\ObjectComparator`