### PR TITLE
MagicCallPath: Fix error when @method can't be parsed.

### DIFF
--- a/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
@@ -101,8 +101,6 @@ class MagicalApi
 }
 
 /**
- * @method void invalidMethodDefinition
- * @method void
  * @method
  */
 class MagicalApiInvalidMethodDefinition

--- a/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
@@ -11,6 +11,8 @@
 
 namespace Prophecy\Doubler\ClassPatch;
 
+use phpDocumentor\Reflection\DocBlock\Tag\Method as LegacyMethod;
+use phpDocumentor\Reflection\DocBlock\Tags\Method;
 use Prophecy\Doubler\Generator\Node\ClassNode;
 use Prophecy\Doubler\Generator\Node\MethodNode;
 use Prophecy\PhpDocumentor\ClassAndInterfaceTagRetriever;
@@ -63,7 +65,9 @@ class MagicCallPatch implements ClassPatchInterface
                 $tagList = $this->tagRetriever->getTagList($reflectionClass);
 
                 foreach ($tagList as $tag) {
-                    $methodName = $tag->getMethodName();
+                    $methodName = ($tag instanceof Method || $tag instanceof LegacyMethod)
+                        ? $tag->getMethodName()
+                        : null;
 
                     if (empty($methodName)) {
                         continue;
@@ -91,4 +95,3 @@ class MagicCallPatch implements ClassPatchInterface
         return 50;
     }
 }
-

--- a/src/Prophecy/PhpDocumentor/ClassAndInterfaceTagRetriever.php
+++ b/src/Prophecy/PhpDocumentor/ClassAndInterfaceTagRetriever.php
@@ -12,6 +12,7 @@
 namespace Prophecy\PhpDocumentor;
 
 use phpDocumentor\Reflection\DocBlock\Tag\MethodTag as LegacyMethodTag;
+use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use phpDocumentor\Reflection\DocBlock\Tags\Method;
 
 /**
@@ -40,7 +41,7 @@ final class ClassAndInterfaceTagRetriever implements MethodTagRetrieverInterface
     /**
      * @param \ReflectionClass $reflectionClass
      *
-     * @return LegacyMethodTag[]|Method[]
+     * @return LegacyMethodTag[]|Method[]|InvalidTag[]
      */
     public function getTagList(\ReflectionClass $reflectionClass)
     {
@@ -53,7 +54,7 @@ final class ClassAndInterfaceTagRetriever implements MethodTagRetrieverInterface
     /**
      * @param \ReflectionClass $reflectionClass
      *
-     * @return LegacyMethodTag[]|Method[]
+     * @return LegacyMethodTag[]|Method[]|InvalidTag[]
      */
     private function getInterfacesTagList(\ReflectionClass $reflectionClass)
     {

--- a/src/Prophecy/PhpDocumentor/MethodTagRetrieverInterface.php
+++ b/src/Prophecy/PhpDocumentor/MethodTagRetrieverInterface.php
@@ -12,6 +12,7 @@
 namespace Prophecy\PhpDocumentor;
 
 use phpDocumentor\Reflection\DocBlock\Tag\MethodTag as LegacyMethodTag;
+use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use phpDocumentor\Reflection\DocBlock\Tags\Method;
 
 /**
@@ -24,7 +25,7 @@ interface MethodTagRetrieverInterface
     /**
      * @param \ReflectionClass $reflectionClass
      *
-     * @return LegacyMethodTag[]|Method[]
+     * @return LegacyMethodTag[]|Method[]|InvalidTag[]
      */
     public function getTagList(\ReflectionClass $reflectionClass);
 }


### PR DESCRIPTION
In some case, the `@method` tag can't be parsed and this will return an
`phpDocumentor\Reflection\DocBlock\Tags\InvalidTag` instance.

The problem is that the `InvalidTag` object doesn't have the `getMethodName` method so it leads to fatal errors during execution:

```
Call to undefined method phpDocumentor\Reflection\DocBlock\Tags\InvalidTag::getMethodName()
```

The problem was found when mocking the `\Fake\Generator` class from `fzaninotto/faker` with the `@method`:

```
@method mixed randomElement(array $array = array('a', 'b', 'c'))
```

Not sure the fix I added is the correct behaviour, the specs must be updated regarding that change for the travis build to pass.