### PR TITLE
Fix the handling of invalid phpdoc tags

### DIFF
--- a/fixtures/WithPhpdocClass.php
+++ b/fixtures/WithPhpdocClass.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Fixtures\Prophecy;
+
+
+/**
+ * @method string name(string $gender = null)
+ * @method mixed randomElement(array $array = array('a', 'b', 'c'))
+ */
+class WithPhpdocClass
+{
+    public function __call($name, $arguments)
+    {
+        // TODO: Implement __call() method.
+    }
+}

--- a/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/MagicCallPatchSpec.php
@@ -101,8 +101,6 @@ class MagicalApi
 }
 
 /**
- * @method void invalidMethodDefinition
- * @method void
  * @method
  */
 class MagicalApiInvalidMethodDefinition

--- a/src/Prophecy/PhpDocumentor/ClassTagRetriever.php
+++ b/src/Prophecy/PhpDocumentor/ClassTagRetriever.php
@@ -44,7 +44,15 @@ final class ClassTagRetriever implements MethodTagRetrieverInterface
                 $this->contextFactory->createFromReflector($reflectionClass)
             );
 
-            return $phpdoc->getTagsByName('method');
+            $methods = array();
+
+            foreach ($phpdoc->getTagsByName('method') as $tag) {
+                if ($tag instanceof Method) {
+                    $methods[] = $tag;
+                }
+            }
+
+            return $methods;
         } catch (\InvalidArgumentException $e) {
             return array();
         }

--- a/tests/Doubler/ClassPatch/MagicCallPatchTest.php
+++ b/tests/Doubler/ClassPatch/MagicCallPatchTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Prophecy\Doubler\ClassPatch;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Doubler\ClassPatch\MagicCallPatch;
+use Prophecy\Doubler\Generator\ClassMirror;
+
+class MagicCallPatchTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_supports_classes_with_invalid_tags()
+    {
+        $class = new \ReflectionClass('Fixtures\Prophecy\WithPhpdocClass');
+
+        $mirror = new ClassMirror();
+        $classNode = $mirror->reflect($class, array());
+
+        $patch = new MagicCallPatch();
+
+        $patch->apply($classNode);
+
+        // Newer phpDocumentor versions allow reading valid method tags, even when some other tags are invalid
+        // Some older versions might also have this method due to not considering the method tag invalid as rule evolved, but we don't track that.
+        if (class_exists('phpDocumentor\Reflection\DocBlock\Tags\InvalidTag')) {
+            $this->assertTrue($classNode->hasMethod('name'));
+        }
+
+        // We expect no error when processing the class patch. But we still need to increment the assertion count.
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Such tags are represented by an InvalidTag instance rather than a Method tag, but the name might still be `method`. As we want to ignore invalid tags (that's the reason to catch exceptions), these tags are filtered out.