### PR TITLE
Fix clone for double object

### DIFF
--- a/spec/Prophecy/Argument/Token/ExactValueTokenSpec.php
+++ b/spec/Prophecy/Argument/Token/ExactValueTokenSpec.php
@@ -41,6 +41,14 @@ class ExactValueTokenSpec extends ObjectBehavior
         $this->scoreArgument($value2)->shouldReturn(10);
     }
 
+    function it_scores_10_if_value_is_an_double_object_and_equal_to_argument(\stdClass $value)
+    {
+        $value2 = clone $value->getWrappedObject();
+
+        $this->beConstructedWith($value);
+        $this->scoreArgument($value2)->shouldReturn(10);
+    }
+
     function it_does_not_scores_if_value_is_not_equal_to_argument()
     {
         $this->scoreArgument(50)->shouldReturn(false);

--- a/spec/Prophecy/Argument/Token/ExactValueTokenSpec.php
+++ b/spec/Prophecy/Argument/Token/ExactValueTokenSpec.php
@@ -41,7 +41,7 @@ class ExactValueTokenSpec extends ObjectBehavior
         $this->scoreArgument($value2)->shouldReturn(10);
     }
 
-    function it_scores_10_if_value_is_an_double_object_and_equal_to_argument(\stdClass $value)
+    function it_scores_10_if_value_is_a_double_object_and_equal_to_argument(\stdClass $value)
     {
         $value2 = clone $value->getWrappedObject();
 

--- a/src/Prophecy/Doubler/ClassPatch/ProphecySubjectPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/ProphecySubjectPatch.php
@@ -65,10 +65,17 @@ class ProphecySubjectPatch implements ClassPatchInterface
         $prophecyArgument = new ArgumentNode('prophecy');
         $prophecyArgument->setTypeHint('Prophecy\Prophecy\ProphecyInterface');
         $prophecySetter->addArgument($prophecyArgument);
-        $prophecySetter->setCode('$this->objectProphecyClosure = function () use ($prophecy) { return $prophecy; };');
+        $prophecySetter->setCode(<<<PHP
+if (null === \$this->objectProphecyClosure) {
+    \$this->objectProphecyClosure = static function () use (\$prophecy) {
+        return \$prophecy;
+    };
+}
+PHP
+    );
 
         $prophecyGetter = new MethodNode('getProphecy');
-        $prophecyGetter->setCode('return call_user_func($this->objectProphecyClosure);');
+        $prophecyGetter->setCode('return \call_user_func($this->objectProphecyClosure);');
 
         if ($node->hasMethod('__call')) {
             $__call = $node->getMethod('__call');


### PR DESCRIPTION
Hello, prophecy has problem with cloned double object.
Here is example:
```
class Foo
{
    private $object;

    public function __construct($object)
    {
        $this->object = clone $object;
    }

    public function getObject()
    {
        return $this->object;
    }
}
```
And spec tests:
```
class FooSpec extends ObjectBehavior
{
    public function it_compares_cloned_object()
    {
        $object = new \stdClass();
        $this->beConstructedWith($object);

        $this->getObject()->shouldBeLike($object);
    }

    public function it_compares_cloned_double_object(\stdClass $object)
    {
        $this->beConstructedWith($object);

        $this->getObject()->shouldBeLike($object);
    }
}
```
I expect the same behavior for two tests but first passed and second failed with error:
```
      - it compares cloned double object
      expected [obj:Double\stdClass\P1], but got [obj:Double\stdClass\P1].
      
      @@ -1,5 +1,5 @@
      -Double\stdClass\P1 Object &000000002e014a3e000000003f3f6471 (
      -    'objectProphecyClosure' => Closure Object &000000002e014a34000000003f3f6471 (
      -        0 => Closure Object &000000002e014a34000000003f3f6471
      +Double\stdClass\P1 Object &000000002e014a22000000003f3f6471 (
      +    'objectProphecyClosure' => Closure Object &000000002e014a3d000000003f3f6471 (
      +        0 => Closure Object &000000002e014a3d000000003f3f6471
           )
       )
```

Also I found the solution and I would like to shere with you.