### PR TITLE
Add method for incrementing a prediction's call times

### DIFF
--- a/src/Prophecy/Prediction/CallTimesPrediction.php
+++ b/src/Prophecy/Prediction/CallTimesPrediction.php
@@ -43,6 +43,15 @@ class CallTimesPrediction implements PredictionInterface
     }
 
     /**
+     * Returns the prediction's times.
+     *
+     * @return int $times
+     */
+    public function getTimes() {
+        return $this->times;
+    }
+
+    /**
      * Tests that there was exact amount of calls made.
      *
      * @param Call[]         $calls

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -313,6 +313,31 @@ class MethodProphecy
     }
 
     /**
+     * Increments the call times prediction for the prophecy.
+     *
+     * If the prediction already exist, it adds the given count to the
+     * prediction's times count.
+     *
+     * If the prediction does not exist, or it is not a call times prediction,
+     * it adds a new call times prediction with the given count.
+     *
+     * @see \Prophecy\Prediction\CallTimesPrediction
+     *
+     * @param $count
+     *
+     * @return $this
+     */
+    public function shouldBeCalledAddTimes($count)
+    {
+        if (!$this->prediction || !$this->prediction instanceof Prediction\CallTimesPrediction) {
+            return $this->shouldBeCalledTimes($count);
+        }
+
+        $times = $this->prediction->getTimes();
+        return $this->should(new Prediction\CallTimesPrediction($times + $count));
+    }
+
+    /**
      * Sets call times prediction to the prophecy.
      *
      * @see \Prophecy\Prediction\CallTimesPrediction


### PR DESCRIPTION
In some complex test cases with data providers I find the need to be able to increment the count of an existing call times prediciton. For example, I register the prediction, but if some condition passes I want to easily increment the count  instead of registering it again. Othewise I'd have to keep track of how many times it should be called and that makes writing the tests more difficult.

I have added a method `shouldBeCalledAddTimes($count)`; if there is an existing call times prediction it will add the given count to the prediction's count, otherwise it will create a new one.

Let me know if that sounds the right approach and I can take this further.