### PR TITLE
PHP 8 support

### DIFF
--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -221,14 +221,6 @@ class ClassMirror
             return $className;
         }
 
-        if (true === $parameter->isArray()) {
-            return 'array';
-        }
-
-        if (true === $parameter->isCallable()) {
-            return 'callable';
-        }
-
         if (true === $parameter->hasType()) {
             return $parameter->getType()->getName();
         }

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -236,20 +236,14 @@ class ClassMirror
 
     private function getParameterClassName(ReflectionParameter $parameter)
     {
-        try {
-            $type = $parameter->getType();
-            if (!$type) {
-                return null;
-            }
-            if ($type instanceof ReflectionNamedType && !$type->isBuiltin()) {
-                return $type->getName();
-            }
-
+        $type = $parameter->getType();
+        if (!$type) {
             return null;
-        } catch (\ReflectionException $e) {
-            preg_match('/\[\s\<\w+?>\s([\w,\\\]+)/s', $parameter, $matches);
-
-            return isset($matches[1]) ? $matches[1] : null;
         }
+        if ($type instanceof ReflectionNamedType && !$type->isBuiltin()) {
+            return $type->getName();
+        }
+
+        return null;
     }
 }

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -15,6 +15,7 @@ use Prophecy\Exception\InvalidArgumentException;
 use Prophecy\Exception\Doubler\ClassMirrorException;
 use ReflectionClass;
 use ReflectionMethod;
+use ReflectionNamedType;
 use ReflectionParameter;
 
 /**
@@ -236,7 +237,15 @@ class ClassMirror
     private function getParameterClassName(ReflectionParameter $parameter)
     {
         try {
-            return $parameter->getClass() ? $parameter->getClass()->getName() : null;
+            $type = $parameter->getType();
+            if (!$type) {
+                return null;
+            }
+            if ($type instanceof ReflectionNamedType && !$type->isBuiltin()) {
+                return $type->getName();
+            }
+
+            return null;
         } catch (\ReflectionException $e) {
             preg_match('/\[\s\<\w+?>\s([\w,\\\]+)/s', $parameter, $matches);
 

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -38,14 +38,13 @@ class ClassMirror
     /**
      * Reflects provided arguments into class node.
      *
-     * @param ReflectionClass   $class
+     * @param ReflectionClass|null $class
      * @param ReflectionClass[] $interfaces
      *
      * @return Node\ClassNode
      *
-     * @throws \Prophecy\Exception\InvalidArgumentException
      */
-    public function reflect(ReflectionClass $class = null, array $interfaces)
+    public function reflect(?ReflectionClass $class, array $interfaces)
     {
         $node = new Node\ClassNode;
 

--- a/src/Prophecy/Doubler/Generator/Node/ArgumentNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/ArgumentNode.php
@@ -92,7 +92,7 @@ class ArgumentNode
 
     public function isNullable()
     {
-        return $this->isNullable;
+        return $this->isNullable && $this->typeHint !== 'mixed';
     }
 
     public function setAsNullable($isNullable = true)

--- a/src/Prophecy/Doubler/Generator/TypeHintReference.php
+++ b/src/Prophecy/Doubler/Generator/TypeHintReference.php
@@ -22,6 +22,9 @@ final class TypeHintReference
             case 'object':
                 return true;
 
+            case 'mixed':
+                return PHP_VERSION_ID >= 80000;
+
             default:
                 return false;
         }

--- a/tests/Doubler/Generator/ClassMirrorTest.php
+++ b/tests/Doubler/Generator/ClassMirrorTest.php
@@ -489,6 +489,8 @@ class ClassMirrorTest extends TestCase
         $parameter->isPassedByReference()->willReturn(false);
         $parameter->allowsNull()->willReturn(true);
         $parameter->getClass()->willReturn($class);
+        $parameter->getType()->willReturn(null);
+        $parameter->hasType()->willReturn(false);
         if (version_compare(PHP_VERSION, '5.6', '>=')) {
             $parameter->isVariadic()->willReturn(false);
         }


### PR DESCRIPTION
Work in progress to bring PHP 8 support for prophecy. 

Majority of the errors were deprecation notices. I fixed the [optional-before-required errors](https://php.watch/versions/8.0/deprecate-required-param-after-optional) and deprecation of `ReflectionParameter` methods [`getClass`, `isCallable`, and `isArray`](https://php.watch/versions/8.0/deprecated-reflectionparameter-methods) with branching code that checks `getType` is available, and then uses it instead of the shorthand now-deprecated functions. 

I'm not completely sure about the fixes related to the new [`mixed` type](https://php.watch/versions/8.0/mixed-type). 

After these changes, there are only 4 errors/failures remaining from PHPUnit:

```
1) Tests\Prophecy\Doubler\ClassPatch\MagicCallPatchTest::it_supports_classes_with_invalid_tags
Method ReflectionParameter::getClass() is deprecated

prophecy/tests/Doubler/ClassPatch/MagicCallPatchTest.php:23

2) Tests\Prophecy\Doubler\Generator\ClassMirrorTest::it_marks_required_args_without_types_as_not_optional
Required parameter $arg_2 follows optional parameter $arg_1

prophecy\fixtures\WithArguments.php:7
prophecy/tests/Doubler/Generator/ClassMirrorTest.php:67

3) Tests\Prophecy\Doubler\Generator\ClassMirrorTest::it_doesnt_use_scalar_typehints
Error: Call to a member function getArguments() on null

prophecy/tests/Doubler/Generator/ClassMirrorTest.php:386

4) Tests\Prophecy\Doubler\Generator\ClassMirrorTest::it_changes_argument_names_if_they_are_varying
Error: Call to undefined method ReflectionUnionType::isBuiltin()

prophecy/tests/Doubler/Generator/ClassMirrorTest.php:480
```

I cannot get xdebug to work with PHP nightly builds, so these errors do not contain any backtraces. Any insights would be appreciated. 
I tried to skip some of the tests (such as `#2` above) with `@require PHP <= 8` annotations for the test because the deprecated behavior is exactly what's this test is asserting. 

`ReflectionParameter::export` method is deprecated, and removed in PHP 8, which causes `#3` above. 