### PR TITLE
Travis CI: Enable builds on PHP nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,16 @@ matrix:
       dist: bionic
     - php: 7.4
       dist: bionic
+    - php: nightly
+      env: COMPOSER_FLAGS='--ignore-platform-reqs'
   fast_finish: true
+  allow_failures:
+    - php: nightly
 
 install:
   - export COMPOSER_ROOT_VERSION=dev-master
-  - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
-  - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; fi;
+  - if [ "$DEPENDENCIES" != "low" ]; then composer update $COMPOSER_FLAGS; fi;
+  - if [ "$DEPENDENCIES" == "low" ]; then composer update $COMPOSER_FLAGS --prefer-lowest; fi;
 
 script:
   - vendor/bin/phpspec run -fpretty -v


### PR DESCRIPTION
Split from #477. 

Contains only updates to Travis builds, so we can get quicker feedback on changes. This will start builds on PHP 8, which will fail, but Travis config allows PHP 8 builds to fail. 