### PR TITLE
Bumped branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "1.10.x-dev"
+            "dev-master": "1.11.x-dev"
         }
     }
 }


### PR DESCRIPTION
Next version will be 1.11.0 (or 2.0.0), but certainly not 1.10.4.