### PR TITLE
Use recommended PHP constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name":         "phpspec/prophecy",
-    "description":  "Highly opinionated mocking framework for PHP 5.3+",
+    "description":  "Highly opinionated mocking framework for PHP",
     "keywords":     ["Mock", "Stub", "Dummy", "Double", "Fake", "Spy"],
     "homepage":     "https://github.com/phpspec/prophecy",
     "type":         "library",
@@ -18,7 +18,7 @@
     ],
 
     "require": {
-        "php":                               "^7.2",
+        "php":                               ">=7.2",
         "phpdocumentor/reflection-docblock": "^5.0",
         "sebastian/comparator":              "^3.0 || ^4.0",
         "doctrine/instantiator":             "^1.2",


### PR DESCRIPTION
```
phpspec/prophecy v1.10.3 requires php ^5.3|^7.0 -> your PHP version (8.0.0-dev) does not satisfy that requirement.
    - phpspec/prophecy 1.11.x-dev requires php ^7.2 -> your PHP version (8.0.0-dev) does not satisfy that requirement.
    - phpspec/prophecy 1.11.0 requires php ^7.2 -> your PHP version (8.0.0-dev) does not satisfy that requirement.
```

It is recommended to keep PHP constraint open, same also do the other frameworks like Symfony and Cake etc.
This allows to easier adjust the code to work with next major early on.