### PR TITLE
Handle "self" type hint

### DIFF
--- a/fixtures/SelfReferencing.php
+++ b/fixtures/SelfReferencing.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Fixtures\Prophecy;
+
+interface SelfReferencing
+{
+    public function __invoke(self $self): self;
+}

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -241,6 +241,10 @@ class ClassMirror
             return null;
         }
         if ($type instanceof ReflectionNamedType && !$type->isBuiltin()) {
+            if ($type->getName() === 'self') {
+                return $parameter->getDeclaringClass()->getName();
+            }
+
             return $type->getName();
         }
 

--- a/tests/Doubler/Generator/ClassMirrorTest.php
+++ b/tests/Doubler/Generator/ClassMirrorTest.php
@@ -458,6 +458,16 @@ class ClassMirrorTest extends TestCase
 
     /**
      * @test
+     * @doesNotPerformAssertions
+     */
+    function it_doesnt_fail_to_mock_self_referencing_interface()
+    {
+        $class = $this->prophesize('Fixtures\Prophecy\SelfReferencing');
+        $class->reveal();
+    }
+
+    /**
+     * @test
      */
     function it_changes_argument_names_if_they_are_varying()
     {


### PR DESCRIPTION
Using self in the implementing class means narrowing the type, and
result in an LSP violation (and a rightful crash from PHP).
Resolving self to the declaring type results in a compatible signature.

Fixes #484