### PR TITLE
Nightly build with edge dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,15 @@ matrix:
       dist: bionic
     - php: nightly
       env: COMPOSER_FLAGS='--ignore-platform-reqs'
+    - php: nightly
+      env: COMPOSER_FLAGS='--ignore-platform-reqs' COMPOSER_FORCE='phpdocumentor/reflection-docblock ^5.0@dev phpunit/phpunit ^9.0@dev'
   fast_finish: true
   allow_failures:
     - php: nightly
 
 install:
   - export COMPOSER_ROOT_VERSION=dev-master
+  - if [ -n "$COMPOSER_FORCE" ]; then composer require $COMPOSER_FORCE --no-update ; fi;
   - if [ "$DEPENDENCIES" != "low" ]; then composer update $COMPOSER_FLAGS; fi;
   - if [ "$DEPENDENCIES" == "low" ]; then composer update $COMPOSER_FLAGS --prefer-lowest; fi;
 


### PR DESCRIPTION
To see where we are with PHP8 support, this added a new build that artificially bumps some of the dependencies to their @dev versions so we can see where we are.

There is 1 phpspec failure and 3 phpunit ones. I've got another branch on the way to fix the phpspec one, the phpunit ones it's unclear where the error is coming from and needs some debug