### PR TITLE
Explicitly convert arguments to ApproximateValueToken to numeric

### DIFF
--- a/src/Prophecy/Argument/Token/ApproximateValueToken.php
+++ b/src/Prophecy/Argument/Token/ApproximateValueToken.php
@@ -32,7 +32,7 @@ class ApproximateValueToken implements TokenInterface
      */
     public function scoreArgument($argument)
     {
-        return round($argument, $this->precision) === round($this->value, $this->precision) ? 10 : false;
+        return round((float)$argument, $this->precision) === round($this->value, $this->precision) ? 10 : false;
     }
 
     /**


### PR DESCRIPTION
round() is more strict in PHP8 so this would cause an issue