### PR TITLE
Check for ReflectionNamedType before asking for the type

### DIFF
--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -222,7 +222,7 @@ class ClassMirror
             return $className;
         }
 
-        if (true === $parameter->hasType()) {
+        if (true === $parameter->hasType() && $parameter->getType() instanceof \ReflectionNamedType) {
             return $parameter->getType()->getName();
         }
 


### PR DESCRIPTION
This fails when presented with a union type (cc @Ayesh)