### PR TITLE
Bump minimum reflection-docblock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - php: nightly
       env: COMPOSER_FLAGS='--ignore-platform-reqs'
     - php: nightly
-      env: COMPOSER_FLAGS='--ignore-platform-reqs' COMPOSER_FORCE='phpdocumentor/reflection-docblock ^5.0@dev phpunit/phpunit ^9.0@dev'
+      env: COMPOSER_FLAGS='--ignore-platform-reqs' COMPOSER_FORCE='phpunit/phpunit ^9.0@dev'
   fast_finish: true
   allow_failures:
     - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 
     "require": {
         "php":                               "^7.2",
-        "phpdocumentor/reflection-docblock": "^5.0",
+        "phpdocumentor/reflection-docblock": "^5.2",
         "sebastian/comparator":              "^3.0 || ^4.0",
         "doctrine/instantiator":             "^1.2",
         "sebastian/recursion-context":       "^3.0 || ^4.0"


### PR DESCRIPTION
So that people running prefer-lowest with ignore-platform-reqs get a working combination of dependencies.

---

Related to https://github.com/sebastianbergmann/phpunit/issues/4325#issuecomment-661312230.