### PR TITLE
Support PHP8's Union and Mixed types

### DIFF
--- a/fixtures/MixedTypes.php
+++ b/fixtures/MixedTypes.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Fixtures\Prophecy;
+
+class MixedTypes
+{
+    public function doSomething(mixed $arg1): mixed
+    {
+
+    }
+}

--- a/fixtures/UnionArgumentTypes.php
+++ b/fixtures/UnionArgumentTypes.php
@@ -4,7 +4,7 @@ namespace Fixtures\Prophecy;
 
 class UnionArgumentTypes
 {
-    public function doSomething(bool|stdClass $arg)
+    public function doSomething(bool|\stdClass $arg)
     {
 
     }

--- a/fixtures/UnionReturnTypes.php
+++ b/fixtures/UnionReturnTypes.php
@@ -4,7 +4,7 @@ namespace Fixtures\Prophecy;
 
 class UnionReturnTypes
 {
-    public function doSomething(): bool|stdClass
+    public function doSomething(): bool|\stdClass
     {
 
     }

--- a/spec/Prophecy/Doubler/ClassPatch/ProphecySubjectPatchSpec.php
+++ b/spec/Prophecy/Doubler/ClassPatch/ProphecySubjectPatchSpec.php
@@ -6,6 +6,7 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Prophecy\Doubler\Generator\Node\ClassNode;
 use Prophecy\Doubler\Generator\Node\MethodNode;
+use Prophecy\Doubler\Generator\Node\ReturnTypeNode;
 
 class ProphecySubjectPatchSpec extends ObjectBehavior
 {
@@ -55,9 +56,9 @@ class ProphecySubjectPatchSpec extends ObjectBehavior
         $method2->getName()->willReturn('method2');
         $method3->getName()->willReturn('method3');
 
-        $method1->getReturnType()->willReturn('int');
-        $method2->getReturnType()->willReturn('int');
-        $method3->getReturnType()->willReturn('void');
+        $method1->getReturnTypeNode()->willReturn(new ReturnTypeNode('int'));
+        $method2->getReturnTypeNode()->willReturn(new ReturnTypeNode('int'));
+        $method3->getReturnTypeNode()->willReturn(new ReturnTypeNode('void'));
 
         $node->getMethods()->willReturn(array(
             'method1' => $method1,

--- a/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
@@ -287,6 +287,44 @@ PHP;
         $code->shouldBe($expected);
     }
 
+    function it_generates_proper_code_for_union_return_types
+    (
+        ClassNode $class,
+        MethodNode $method,
+        ArgumentNode $argument
+    )
+    {
+        $class->getParentClass()->willReturn('stdClass');
+        $class->getInterfaces()->willReturn([]);
+        $class->getProperties()->willReturn([]);
+        $class->getMethods()->willReturn(array($method));
+
+        $method->getName()->willReturn('foo');
+        $method->getVisibility()->willReturn('public');
+        $method->isStatic()->willReturn(false);
+        $method->getArguments()->willReturn([]);
+        $method->getReturnTypeNode()->willReturn(new ReturnTypeNode('int', 'string', 'null'));
+        $method->returnsReference()->willReturn(false);
+        $method->getCode()->willReturn('');
+
+        $code = $this->generate('CustomClass', $class);
+
+        $expected =<<<'PHP'
+namespace  {
+class CustomClass extends \stdClass implements  {
+
+public  function foo(): int|string|null {
+
+}
+
+}
+}
+PHP;
+        $expected = strtr($expected, array("\r\n" => "\n", "\r" => "\n"));
+
+        $code->shouldBe($expected);
+    }
+
     function it_generates_empty_class_for_empty_ClassNode(ClassNode $class)
     {
         $class->getParentClass()->willReturn('stdClass');

--- a/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
@@ -6,6 +6,7 @@ use phpDocumentor\Reflection\DocBlock\Tags\Method;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Prophecy\Doubler\Generator\Node\ArgumentNode;
+use Prophecy\Doubler\Generator\Node\ArgumentTypeNode;
 use Prophecy\Doubler\Generator\Node\ClassNode;
 use Prophecy\Doubler\Generator\Node\MethodNode;
 use Prophecy\Doubler\Generator\Node\ReturnTypeNode;
@@ -73,42 +74,38 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method5->getCode()->willReturn('return;');
 
         $argument11->getName()->willReturn('fullname');
-        $argument11->getTypeHint()->willReturn('array');
         $argument11->isOptional()->willReturn(true);
         $argument11->getDefault()->willReturn(null);
         $argument11->isPassedByReference()->willReturn(false);
         $argument11->isVariadic()->willReturn(false);
-        $argument11->isNullable()->willReturn(false);
+        $argument11->getTypeNode()->willReturn(new ArgumentTypeNode('array'));
 
         $argument12->getName()->willReturn('class');
-        $argument12->getTypeHint()->willReturn('ReflectionClass');
         $argument12->isOptional()->willReturn(false);
         $argument12->isPassedByReference()->willReturn(false);
         $argument12->isVariadic()->willReturn(false);
-        $argument12->isNullable()->willReturn(false);
+        $argument12->getTypeNode()->willReturn(new ArgumentTypeNode('ReflectionClass'));
 
         $argument13->getName()->willReturn('instance');
-        $argument13->getTypeHint()->willReturn('object');
         $argument13->isOptional()->willReturn(false);
         $argument13->isPassedByReference()->willReturn(false);
         $argument13->isVariadic()->willReturn(false);
-        $argument13->isNullable()->willReturn(false);
+        $argument13->getTypeNode()->willReturn(new ArgumentTypeNode('object'));
 
         $argument21->getName()->willReturn('default');
-        $argument21->getTypeHint()->willReturn('string');
         $argument21->isOptional()->willReturn(true);
         $argument21->getDefault()->willReturn('ever.zet@gmail.com');
         $argument21->isPassedByReference()->willReturn(false);
         $argument21->isVariadic()->willReturn(false);
-        $argument21->isNullable()->willReturn(true);
+        $argument21->getTypeNode()->willReturn(new ArgumentTypeNode('string', 'null'));
 
         $argument31->getName()->willReturn('refValue');
-        $argument31->getTypeHint()->willReturn(null);
         $argument31->isOptional()->willReturn(false);
         $argument31->getDefault()->willReturn();
         $argument31->isPassedByReference()->willReturn(false);
         $argument31->isVariadic()->willReturn(false);
-        $argument31->isNullable()->willReturn(false);
+        $argument31->getTypeNode()->willReturn(new ArgumentTypeNode());
+
 
         $code = $this->generate('CustomClass', $class);
 
@@ -193,32 +190,29 @@ PHP;
         $method4->getCode()->willReturn('');
 
         $argument1->getName()->willReturn('args');
-        $argument1->getTypeHint()->willReturn(null);
         $argument1->isOptional()->willReturn(false);
         $argument1->isPassedByReference()->willReturn(false);
         $argument1->isVariadic()->willReturn(true);
-        $argument1->isNullable()->willReturn(false);
+        $argument1->getTypeNode()->willReturn(new ArgumentTypeNode());
 
         $argument2->getName()->willReturn('args');
-        $argument2->getTypeHint()->willReturn(null);
         $argument2->isOptional()->willReturn(false);
         $argument2->isPassedByReference()->willReturn(true);
         $argument2->isVariadic()->willReturn(true);
-        $argument2->isNullable()->willReturn(false);
+        $argument2->getTypeNode()->willReturn(new ArgumentTypeNode());
 
         $argument3->getName()->willReturn('args');
-        $argument3->getTypeHint()->willReturn('\ReflectionClass');
         $argument3->isOptional()->willReturn(false);
         $argument3->isPassedByReference()->willReturn(false);
         $argument3->isVariadic()->willReturn(true);
-        $argument3->isNullable()->willReturn(false);
+        $argument3->getTypeNode()->willReturn(new ArgumentTypeNode('ReflectionClass'));
 
         $argument4->getName()->willReturn('args');
-        $argument4->getTypeHint()->willReturn('\ReflectionClass');
         $argument4->isOptional()->willReturn(false);
         $argument4->isPassedByReference()->willReturn(true);
         $argument4->isVariadic()->willReturn(true);
-        $argument4->isNullable()->willReturn(false);
+        $argument4->getTypeNode()->willReturn(new ArgumentTypeNode('ReflectionClass'));
+
 
         $code = $this->generate('CustomClass', $class);
         $expected = <<<'PHP'
@@ -231,10 +225,10 @@ public  function variadic( ...$args) {
 public  function variadicByRef( &...$args) {
 
 }
-public  function variadicWithType(\\ReflectionClass ...$args) {
+public  function variadicWithType(\ReflectionClass ...$args) {
 
 }
-public  function variadicWithTypeByRef(\\ReflectionClass &...$args) {
+public  function variadicWithTypeByRef(\ReflectionClass &...$args) {
 
 }
 
@@ -264,12 +258,11 @@ PHP;
         $method->getCode()->willReturn('return $this->name;');
 
         $argument->getName()->willReturn('fullname');
-        $argument->getTypeHint()->willReturn('array');
         $argument->isOptional()->willReturn(true);
         $argument->getDefault()->willReturn(null);
         $argument->isPassedByReference()->willReturn(true);
         $argument->isVariadic()->willReturn(false);
-        $argument->isNullable()->willReturn(false);
+        $argument->getTypeNode()->willReturn(new ArgumentTypeNode('array'));
 
         $code = $this->generate('CustomClass', $class);
         $expected =<<<'PHP'

--- a/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
@@ -45,7 +45,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method2->returnsReference()->willReturn(false);
         $method2->isStatic()->willReturn(false);
         $method2->getArguments()->willReturn(array($argument21));
-        $method2->getReturnTypeNode()->willReturn(new ReturnTypenode());
+        $method2->getReturnTypeNode()->willReturn(new ReturnTypeNode());
         $method2->getCode()->willReturn('return $this->email;');
 
         $method3->getName()->willReturn('getRefValue');
@@ -61,7 +61,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method4->returnsReference()->willReturn(false);
         $method4->isStatic()->willReturn(false);
         $method4->getArguments()->willReturn(array());
-        $method4->getReturnTypeNode()->willReturn(new ReturnTypenode('void'));
+        $method4->getReturnTypeNode()->willReturn(new ReturnTypeNode('void'));
         $method4->getCode()->willReturn('return;');
 
         $method5->getName()->willReturn('returnObject');
@@ -69,7 +69,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method5->returnsReference()->willReturn(false);
         $method5->isStatic()->willReturn(false);
         $method5->getArguments()->willReturn(array());
-        $method5->getReturnTypeNode()->willReturn(new ReturnTypenode('object'));
+        $method5->getReturnTypeNode()->willReturn(new ReturnTypeNode('object'));
         $method5->getCode()->willReturn('return;');
 
         $argument11->getName()->willReturn('fullname');

--- a/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
@@ -8,6 +8,7 @@ use Prophecy\Argument;
 use Prophecy\Doubler\Generator\Node\ArgumentNode;
 use Prophecy\Doubler\Generator\Node\ClassNode;
 use Prophecy\Doubler\Generator\Node\MethodNode;
+use Prophecy\Doubler\Generator\Node\ReturnTypeNode;
 
 class ClassCodeGeneratorSpec extends ObjectBehavior
 {
@@ -36,9 +37,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method1->returnsReference()->willReturn(false);
         $method1->isStatic()->willReturn(true);
         $method1->getArguments()->willReturn(array($argument11, $argument12, $argument13));
-        $method1->hasReturnType()->willReturn(true);
-        $method1->getReturnType()->willReturn('string');
-        $method1->hasNullableReturnType()->willReturn(true);
+        $method1->getReturnTypeNode()->willReturn(new ReturnTypeNode('string', 'null'));
         $method1->getCode()->willReturn('return $this->name;');
 
         $method2->getName()->willReturn('getEmail');
@@ -46,8 +45,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method2->returnsReference()->willReturn(false);
         $method2->isStatic()->willReturn(false);
         $method2->getArguments()->willReturn(array($argument21));
-        $method2->hasReturnType()->willReturn(false);
-        $method2->hasNullableReturnType()->willReturn(true);
+        $method2->getReturnTypeNode()->willReturn(new ReturnTypenode());
         $method2->getCode()->willReturn('return $this->email;');
 
         $method3->getName()->willReturn('getRefValue');
@@ -55,9 +53,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method3->returnsReference()->willReturn(true);
         $method3->isStatic()->willReturn(false);
         $method3->getArguments()->willReturn(array($argument31));
-        $method3->hasReturnType()->willReturn(true);
-        $method3->getReturnType()->willReturn('string');
-        $method3->hasNullableReturnType()->willReturn(false);
+        $method3->getReturnTypeNode()->willReturn(new ReturnTypeNode('string'));
         $method3->getCode()->willReturn('return $this->refValue;');
 
         $method4->getName()->willReturn('doSomething');
@@ -65,9 +61,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method4->returnsReference()->willReturn(false);
         $method4->isStatic()->willReturn(false);
         $method4->getArguments()->willReturn(array());
-        $method4->hasReturnType()->willReturn(true);
-        $method4->getReturnType()->willReturn('void');
-        $method4->hasNullableReturnType()->willReturn(false);
+        $method4->getReturnTypeNode()->willReturn(new ReturnTypenode('void'));
         $method4->getCode()->willReturn('return;');
 
         $method5->getName()->willReturn('returnObject');
@@ -75,9 +69,7 @@ class ClassCodeGeneratorSpec extends ObjectBehavior
         $method5->returnsReference()->willReturn(false);
         $method5->isStatic()->willReturn(false);
         $method5->getArguments()->willReturn(array());
-        $method5->hasReturnType()->willReturn(true);
-        $method5->getReturnType()->willReturn('object');
-        $method5->hasNullableReturnType()->willReturn(false);
+        $method5->getReturnTypeNode()->willReturn(new ReturnTypenode('object'));
         $method5->getCode()->willReturn('return;');
 
         $argument11->getName()->willReturn('fullname');
@@ -173,7 +165,7 @@ PHP;
         $method1->returnsReference()->willReturn(false);
         $method1->isStatic()->willReturn(false);
         $method1->getArguments()->willReturn(array($argument1));
-        $method1->hasReturnType()->willReturn(false);
+        $method1->getReturnTypeNode()->willReturn(new ReturnTypeNode());
         $method1->getCode()->willReturn('');
 
         $method2->getName()->willReturn('variadicByRef');
@@ -181,7 +173,7 @@ PHP;
         $method2->returnsReference()->willReturn(false);
         $method2->isStatic()->willReturn(false);
         $method2->getArguments()->willReturn(array($argument2));
-        $method2->hasReturnType()->willReturn(false);
+        $method2->getReturnTypeNode()->willReturn(new ReturnTypeNode());
         $method2->getCode()->willReturn('');
 
         $method3->getName()->willReturn('variadicWithType');
@@ -189,7 +181,7 @@ PHP;
         $method3->returnsReference()->willReturn(false);
         $method3->isStatic()->willReturn(false);
         $method3->getArguments()->willReturn(array($argument3));
-        $method3->hasReturnType()->willReturn(false);
+        $method3->getReturnTypeNode()->willReturn(new ReturnTypeNode());
         $method3->getCode()->willReturn('');
 
         $method4->getName()->willReturn('variadicWithTypeByRef');
@@ -197,7 +189,7 @@ PHP;
         $method4->returnsReference()->willReturn(false);
         $method4->isStatic()->willReturn(false);
         $method4->getArguments()->willReturn(array($argument4));
-        $method4->hasReturnType()->willReturn(false);
+        $method4->getReturnTypeNode()->willReturn(new ReturnTypeNode());
         $method4->getCode()->willReturn('');
 
         $argument1->getName()->willReturn('args');
@@ -267,7 +259,7 @@ PHP;
         $method->getVisibility()->willReturn('public');
         $method->isStatic()->willReturn(false);
         $method->getArguments()->willReturn(array($argument));
-        $method->hasReturnType()->willReturn(false);
+        $method->getReturnTypeNode()->willReturn(new ReturnTypeNode());
         $method->returnsReference()->willReturn(false);
         $method->getCode()->willReturn('return $this->name;');
 

--- a/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
+++ b/spec/Prophecy/Doubler/Generator/ClassCodeGeneratorSpec.php
@@ -283,8 +283,7 @@ PHP;
     function it_generates_proper_code_for_union_return_types
     (
         ClassNode $class,
-        MethodNode $method,
-        ArgumentNode $argument
+        MethodNode $method
     )
     {
         $class->getParentClass()->willReturn('stdClass');
@@ -307,6 +306,50 @@ namespace  {
 class CustomClass extends \stdClass implements  {
 
 public  function foo(): int|string|null {
+
+}
+
+}
+}
+PHP;
+        $expected = strtr($expected, array("\r\n" => "\n", "\r" => "\n"));
+
+        $code->shouldBe($expected);
+    }
+
+    function it_generates_proper_code_for_union_argument_types
+    (
+        ClassNode $class,
+        MethodNode $method,
+        ArgumentNode $argument
+    )
+    {
+        $class->getParentClass()->willReturn('stdClass');
+        $class->getInterfaces()->willReturn([]);
+        $class->getProperties()->willReturn([]);
+        $class->getMethods()->willReturn(array($method));
+
+        $method->getName()->willReturn('foo');
+        $method->getVisibility()->willReturn('public');
+        $method->isStatic()->willReturn(false);
+        $method->getArguments()->willReturn([$argument]);
+        $method->getReturnTypeNode()->willReturn(new ReturnTypeNode());
+        $method->returnsReference()->willReturn(false);
+        $method->getCode()->willReturn('');
+
+        $argument->getTypeNode()->willReturn(new ArgumentTypeNode('int', 'string', 'null'));
+        $argument->getName()->willReturn('arg');
+        $argument->isPassedByReference()->willReturn(false);
+        $argument->isVariadic()->willReturn(false);
+        $argument->isOptional()->willReturn(false);
+
+        $code = $this->generate('CustomClass', $class);
+
+        $expected =<<<'PHP'
+namespace  {
+class CustomClass extends \stdClass implements  {
+
+public  function foo(int|string|null $arg) {
 
 }
 

--- a/spec/Prophecy/Doubler/Generator/Node/ArgumentNodeSpec.php
+++ b/spec/Prophecy/Doubler/Generator/Node/ArgumentNodeSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Prophecy\Doubler\Generator\Node;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Doubler\Generator\Node\ArgumentTypeNode;
 
 class ArgumentNodeSpec extends ObjectBehavior
 {
@@ -62,10 +63,40 @@ class ArgumentNodeSpec extends ObjectBehavior
         $this->getTypeHint()->shouldReturn(null);
     }
 
-    function its_typeHint_is_mutable()
+    function its_typeHint_is_mutable_with_deprecated_accessors()
     {
         $this->setTypeHint('array');
         $this->getTypeHint()->shouldReturn('array');
+    }
+
+    function it_can_set_nullable_type_using_deprecated_method()
+    {
+        $this->setTypeHint('int');
+
+        $this->setAsNullable();
+
+        $this->shouldBeNullable();
+    }
+
+    function it_can_unset_nullable_type_using_deprecated_method()
+    {
+        $this->setTypeHint('int');
+
+        $this->setAsNullable(false);
+
+        $this->shouldNotBeNullable();
+    }
+
+    function it_has_an_empty_type_by_default()
+    {
+        $this->getTypeNode()->shouldBeLike(new ArgumentTypeNode());
+    }
+
+    function it_has_a_mutable_type()
+    {
+        $this->setTypeNode(new ArgumentTypeNode('int'));
+
+        $this->getTypeNode()->shouldBeLike(new ArgumentTypeNode('int'));
     }
 
     function it_does_not_have_default_value_by_default()

--- a/spec/Prophecy/Doubler/Generator/Node/ArgumentTypeNodeSpec.php
+++ b/spec/Prophecy/Doubler/Generator/Node/ArgumentTypeNodeSpec.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace spec\Prophecy\Doubler\Generator\Node;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Doubler\Generator\Node\ArgumentTypeNode;
+use Prophecy\Exception\Doubler\DoubleException;
+
+class ArgumentTypeNodeSpec extends ObjectBehavior
+{
+    function it_has_no_types_at_start()
+    {
+        $this->getTypes()->shouldReturn([]);
+    }
+
+    function it_can_have_a_simple_type()
+    {
+        $this->beConstructedWith('int');
+
+        $this->getTypes()->shouldReturn(['int']);
+    }
+
+    function it_can_have_multiple_types()
+    {
+        $this->beConstructedWith('int', 'string');
+
+        $this->getTypes()->shouldReturn(['int', 'string']);
+    }
+
+    function it_will_prefix_fcqns()
+    {
+        $this->beConstructedWith('Foo');
+
+        $this->getTypes()->shouldReturn(['\\Foo']);
+    }
+
+    function it_will_not_prefix_fcqns_that_already_have_prefix()
+    {
+        $this->beConstructedWith('\\Foo');
+
+        $this->getTypes()->shouldReturn(['\\Foo']);
+    }
+
+    function it_can_use_shorthand_null_syntax_if_it_has_single_type_plus_null()
+    {
+        $this->beConstructedWith('int', 'null');
+
+        $this->canUseNullShorthand()->shouldReturn(true);
+    }
+
+    function it_can_not_use_shorthand_null_syntax_if_it_does_not_allow_null()
+    {
+        $this->beConstructedWith('int');
+
+        $this->canUseNullShorthand()->shouldReturn(false);
+    }
+
+    function it_can_not_use_shorthand_null_syntax_if_it_has_more_than_one_non_null_type()
+    {
+        $this->beConstructedWith('int', 'string', 'null');
+
+        $this->canUseNullShorthand()->shouldReturn(false);
+    }
+
+    function it_can_return_non_null_types()
+    {
+        $this->beConstructedWith('int', 'null');
+
+        $this->getNonNullTypes()->shouldReturn(['int']);
+    }
+
+    function it_does_not_allow_standalone_null()
+    {
+        $this->beConstructedWith('null');
+
+        $this->shouldThrow(DoubleException::class)->duringInstantiation();
+    }
+
+    function it_does_not_allow_union_mixed()
+    {
+        $this->beConstructedWith('mixed', 'int');
+
+        if (PHP_VERSION_ID >=80000) {
+            $this->shouldThrow(DoubleException::class)->duringInstantiation();
+        }
+    }
+}

--- a/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
+++ b/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
@@ -4,6 +4,7 @@ namespace spec\Prophecy\Doubler\Generator\Node;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Doubler\Generator\Node\ArgumentNode;
+use Prophecy\Doubler\Generator\Node\ReturnTypeNode;
 
 class MethodNodeSpec extends ObjectBehavior
 {
@@ -53,24 +54,6 @@ class MethodNodeSpec extends ObjectBehavior
     function it_accepts_only_supported_visibilities()
     {
         $this->shouldThrow('InvalidArgumentException')->duringSetVisibility('stealth');
-    }
-
-    function it_can_set_nullable_type_using_deprecated_method()
-    {
-        $this->setReturnType('int');
-
-        $this->setNullableReturnType();
-
-        $this->hasNullableReturnType()->shouldBe(true);
-    }
-
-    function it_can_unset_nullable_type_using_deprecated_method()
-    {
-        $this->setReturnType('int');
-
-        $this->setNullableReturnType(false);
-
-        $this->hasNullableReturnType()->shouldBe(false);
     }
 
     function it_lowercases_visibility_before_setting_it()
@@ -135,45 +118,42 @@ class MethodNodeSpec extends ObjectBehavior
         $this->getArguments()->shouldReturn(array($argument1, $argument2));
     }
 
-    function it_does_not_have_return_type_by_default()
+    function it_has_an_empty_return_type_by_default()
     {
-        $this->hasReturnType()->shouldReturn(false);
+        $this->getReturnTypeNode()->shouldBeLike(new ReturnTypeNode());
     }
 
-    function it_setReturnType_sets_return_type()
+    function it_can_modify_return_type()
     {
-        $returnType = 'array';
+        $this->setReturnTypeNode(new ReturnTypeNode('array'));
 
-        $this->setReturnType($returnType);
+        $this->getReturnTypeNode()->shouldBeLike(new ReturnTypeNode('array'));
+    }
+
+    function it_can_modify_return_type_as_strings_using_deprecated_methods()
+    {
+        $this->setReturnType('array');
 
         $this->hasReturnType()->shouldReturn(true);
-        $this->getReturnType()->shouldReturn($returnType);
+        $this->getReturnType()->shouldReturn('array');
     }
 
-    function it_handles_object_return_type()
+    function it_can_set_nullable_type_using_deprecated_method()
     {
-        $this->setReturnType('object');
-        $this->getReturnType()->shouldReturn('object');
+        $this->setReturnType('int');
+
+        $this->setNullableReturnType();
+
+        $this->hasNullableReturnType()->shouldBe(true);
     }
 
-    function it_handles_type_aliases()
+    function it_can_unset_nullable_type_using_deprecated_method()
     {
-        $this->setReturnType('double');
-        $this->getReturnType()->shouldReturn('float');
+        $this->setReturnType('int');
 
-        $this->setReturnType('real');
-        $this->getReturnType()->shouldReturn('float');
+        $this->setNullableReturnType(false);
 
-        $this->setReturnType('boolean');
-        $this->getReturnType()->shouldReturn('bool');
-
-        $this->setReturnType('integer');
-        $this->getReturnType()->shouldReturn('int');
+        $this->hasNullableReturnType()->shouldBe(false);
     }
 
-    function it_handles_null_return_type()
-    {
-        $this->setReturnType(null);
-        $this->getReturnType()->shouldReturn(null);
-    }
 }

--- a/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
+++ b/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
@@ -55,6 +55,24 @@ class MethodNodeSpec extends ObjectBehavior
         $this->shouldThrow('InvalidArgumentException')->duringSetVisibility('stealth');
     }
 
+    function it_can_set_nullable_type_using_deprecated_method()
+    {
+        $this->setReturnType('int');
+
+        $this->setNullableReturnType();
+
+        $this->hasNullableReturnType()->shouldBe(true);
+    }
+
+    function it_can_unset_nullable_type_using_deprecated_method()
+    {
+        $this->setReturnType('int');
+
+        $this->setNullableReturnType(false);
+
+        $this->hasNullableReturnType()->shouldBe(false);
+    }
+
     function it_lowercases_visibility_before_setting_it()
     {
         $this->setVisibility('Public');

--- a/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
+++ b/spec/Prophecy/Doubler/Generator/Node/MethodNodeSpec.php
@@ -144,7 +144,7 @@ class MethodNodeSpec extends ObjectBehavior
 
         $this->setNullableReturnType();
 
-        $this->hasNullableReturnType()->shouldBe(true);
+        $this->shouldHaveNullableReturnType();
     }
 
     function it_can_unset_nullable_type_using_deprecated_method()
@@ -153,7 +153,7 @@ class MethodNodeSpec extends ObjectBehavior
 
         $this->setNullableReturnType(false);
 
-        $this->hasNullableReturnType()->shouldBe(false);
+        $this->shouldNotHaveNullableReturnType();
     }
 
 }

--- a/spec/Prophecy/Doubler/Generator/Node/ReturnTypeNodeSpec.php
+++ b/spec/Prophecy/Doubler/Generator/Node/ReturnTypeNodeSpec.php
@@ -104,4 +104,18 @@ class ReturnTypeNodeSpec extends ObjectBehavior
             $this->shouldThrow(DoubleException::class)->duringInstantiation();
         }
     }
+
+    function it_knows_when_it_is_not_void()
+    {
+        $this->beConstructedWith('int');
+
+        $this->shouldNotBeVoid();
+    }
+
+    function it_knows_when_it_is_void()
+    {
+        $this->beConstructedWith('void');
+
+        $this->shouldBeVoid();
+    }
 }

--- a/spec/Prophecy/Doubler/Generator/Node/ReturnTypeNodeSpec.php
+++ b/spec/Prophecy/Doubler/Generator/Node/ReturnTypeNodeSpec.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace spec\Prophecy\Doubler\Generator\Node;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Exception\Doubler\DoubleException;
+
+class ReturnTypeNodeSpec extends ObjectBehavior
+{
+    function it_has_no_return_types_at_start()
+    {
+        $this->getTypes()->shouldReturn([]);
+    }
+
+    function it_can_have_a_simple_type()
+    {
+        $this->beConstructedWith('int');
+
+        $this->getTypes()->shouldReturn(['int']);
+    }
+
+    function it_can_have_multiple_types()
+    {
+        $this->beConstructedWith('int', 'string');
+
+        $this->getTypes()->shouldReturn(['int', 'string']);
+    }
+
+    function it_can_have_void_type()
+    {
+        $this->beConstructedWith('void');
+
+        $this->getTypes()->shouldReturn(['void']);
+    }
+
+    function it_will_normalise_type_aliases_types()
+    {
+        $this->beConstructedWith('double', 'real', 'boolean', 'integer');
+
+        $this->getTypes()->shouldReturn(['float', 'bool', 'int']);
+    }
+
+    function it_will_prefix_fcqns()
+    {
+        $this->beConstructedWith('Foo');
+
+        $this->getTypes()->shouldReturn(['\\Foo']);
+    }
+
+    function it_will_not_prefix_fcqns_that_already_have_prefix()
+    {
+        $this->beConstructedWith('\\Foo');
+
+        $this->getTypes()->shouldReturn(['\\Foo']);
+    }
+
+    function it_can_use_shorthand_null_syntax_if_it_has_single_type_plus_null()
+    {
+        $this->beConstructedWith('int', 'null');
+
+        $this->canUseNullShorthand()->shouldReturn(true);
+    }
+
+    function it_can_not_use_shorthand_null_syntax_if_it_does_not_allow_null()
+    {
+        $this->beConstructedWith('int');
+
+        $this->canUseNullShorthand()->shouldReturn(false);
+    }
+
+    function it_can_not_use_shorthand_null_syntax_if_it_has_more_than_one_non_null_type()
+    {
+        $this->beConstructedWith('int', 'string', 'null');
+
+        $this->canUseNullShorthand()->shouldReturn(false);
+    }
+
+    function it_can_return_non_null_types()
+    {
+        $this->beConstructedWith('int', 'null');
+
+        $this->getNonNullTypes()->shouldReturn(['int']);
+    }
+
+    function it_does_not_allow_standalone_null()
+    {
+        $this->beConstructedWith('null');
+
+        $this->shouldThrow(DoubleException::class)->duringInstantiation();
+    }
+
+    function it_does_not_allow_union_void()
+    {
+        $this->beConstructedWith('void', 'int');
+
+        $this->shouldThrow(DoubleException::class)->duringInstantiation();
+    }
+
+    function it_does_not_allow_union_mixed()
+    {
+        $this->beConstructedWith('mixed', 'int');
+
+        if (PHP_VERSION_ID >=80000) {
+            $this->shouldThrow(DoubleException::class)->duringInstantiation();
+        }
+    }
+}

--- a/src/Prophecy/Doubler/ClassPatch/ProphecySubjectPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/ProphecySubjectPatch.php
@@ -11,6 +11,7 @@
 
 namespace Prophecy\Doubler\ClassPatch;
 
+use Prophecy\Doubler\Generator\Node\ArgumentTypeNode;
 use Prophecy\Doubler\Generator\Node\ClassNode;
 use Prophecy\Doubler\Generator\Node\MethodNode;
 use Prophecy\Doubler\Generator\Node\ArgumentNode;
@@ -64,7 +65,7 @@ class ProphecySubjectPatch implements ClassPatchInterface
 
         $prophecySetter = new MethodNode('setProphecy');
         $prophecyArgument = new ArgumentNode('prophecy');
-        $prophecyArgument->setTypeHint('Prophecy\Prophecy\ProphecyInterface');
+        $prophecyArgument->setTypeNode(new ArgumentTypeNode('Prophecy\Prophecy\ProphecyInterface'));
         $prophecySetter->addArgument($prophecyArgument);
         $prophecySetter->setCode(<<<PHP
 if (null === \$this->objectProphecyClosure) {

--- a/src/Prophecy/Doubler/ClassPatch/ProphecySubjectPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/ProphecySubjectPatch.php
@@ -14,6 +14,7 @@ namespace Prophecy\Doubler\ClassPatch;
 use Prophecy\Doubler\Generator\Node\ClassNode;
 use Prophecy\Doubler\Generator\Node\MethodNode;
 use Prophecy\Doubler\Generator\Node\ArgumentNode;
+use Prophecy\Doubler\Generator\Node\ReturnTypeNode;
 
 /**
  * Add Prophecy functionality to the double.
@@ -50,7 +51,7 @@ class ProphecySubjectPatch implements ClassPatchInterface
                 continue;
             }
 
-            if ($method->getReturnType() === 'void') {
+            if ($method->getReturnTypeNode()->isVoid()) {
                 $method->setCode(
                     '$this->getProphecy()->makeProphecyMethodCall(__FUNCTION__, func_get_args());'
                 );

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -19,14 +19,8 @@ namespace Prophecy\Doubler\Generator;
  */
 class ClassCodeGenerator
 {
-    /**
-     * @var TypeHintReference
-     */
-    private $typeHintReference;
-
     public function __construct(TypeHintReference $typeHintReference = null)
     {
-        $this->typeHintReference = $typeHintReference ?: new TypeHintReference();
     }
 
     /**
@@ -98,8 +92,7 @@ class ClassCodeGenerator
 
     private function generateArguments(array $arguments)
     {
-        $typeHintReference = $this->typeHintReference;
-        return array_map(function (Node\ArgumentNode $argument) use ($typeHintReference) {
+        return array_map(static function (Node\ArgumentNode $argument){
 
             $type = $argument->getTypeNode();
 

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -11,6 +11,9 @@
 
 namespace Prophecy\Doubler\Generator;
 
+use Prophecy\Doubler\Generator\Node\ReturnTypeNode;
+use Prophecy\Doubler\Generator\Node\TypeNodeAbstract;
+
 /**
  * Class code creator.
  * Generates PHP code for specific class node tree.
@@ -64,44 +67,32 @@ class ClassCodeGenerator
             $method->returnsReference() ? '&':'',
             $method->getName(),
             implode(', ', $this->generateArguments($method->getArguments())),
-            $this->getReturnType($method)
+            ($ret = $this->generateTypes($method->getReturnTypeNode())) ? ': '.$ret : ''
         );
         $php .= $method->getCode()."\n";
 
         return $php.'}';
     }
 
-    /**
-     * @return string
-     */
-    private function getReturnType(Node\MethodNode $method): string
+    private function generateTypes(TypeNodeAbstract $typeNode): string
     {
-        $typeNode = $method->getReturnTypeNode();
-
         if (!$typeNode->getTypes()) {
             return '';
         }
 
-        // When we require PHP 8 we can stop generating ?foo nullables and remove this block
+        // When we require PHP 8 we can stop generating ?foo nullables and remove this first block
         if ($typeNode->canUseNullShorthand()) {
-            return sprintf($typeNode->canUseNullShorthand() ? ': ?%s' : ': %s', $typeNode->getNonNullTypes()[0]);
+            return sprintf( '?%s', $typeNode->getNonNullTypes()[0]);
         } else {
-            return sprintf(': %s',  join('|', $typeNode->getTypes()));
+            return join('|', $typeNode->getTypes());
         }
     }
 
     private function generateArguments(array $arguments)
     {
-        return array_map(static function (Node\ArgumentNode $argument){
+        return array_map(function (Node\ArgumentNode $argument){
 
-            $type = $argument->getTypeNode();
-
-            if ($type->canUseNullShorthand()) {
-                $php = '?' . join('|', $type->getNonNullTypes());
-            }
-            else {
-                $php = join('|', $type->getTypes());
-            }
+            $php = $this->generateTypes($argument->getTypeNode());
 
             $php .= ' '.($argument->isPassedByReference() ? '&' : '');
 

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -84,12 +84,16 @@ class ClassCodeGenerator
     {
         $typeNode = $method->getReturnTypeNode();
 
-        // assume no union types supported yet
-        if (isset($typeNode->getNonNullTypes()[0])) {
-            return sprintf($typeNode->canUseNullShorthand() ? ': ?%s':': %s', $typeNode->getNonNullTypes()[0]);
+        if (!$typeNode->getTypes()) {
+            return '';
         }
 
-        return '';
+        // When we require PHP 8 we can stop generating ?foo nullables and remove this block
+        if ($typeNode->canUseNullShorthand()) {
+            return sprintf($typeNode->canUseNullShorthand() ? ': ?%s' : ': %s', $typeNode->getNonNullTypes()[0]);
+        } else {
+            return sprintf(': %s',  join('|', $typeNode->getTypes()));
+        }
     }
 
     private function generateArguments(array $arguments)

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -80,12 +80,13 @@ class ClassCodeGenerator
     /**
      * @return string
      */
-    private function getReturnType(Node\MethodNode $method)
+    private function getReturnType(Node\MethodNode $method): string
     {
-        if ($method->hasReturnType()) {
-            return $method->hasNullableReturnType()
-                ? sprintf(': ?%s', $method->getReturnType())
-                : sprintf(': %s', $method->getReturnType());
+        $typeNode = $method->getReturnTypeNode();
+
+        // assume no union types supported yet
+        if (isset($typeNode->getNonNullTypes()[0])) {
+            return sprintf($typeNode->canUseNullShorthand() ? ': ?%s':': %s', $typeNode->getNonNullTypes()[0]);
         }
 
         return '';

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -100,10 +100,14 @@ class ClassCodeGenerator
     {
         $typeHintReference = $this->typeHintReference;
         return array_map(function (Node\ArgumentNode $argument) use ($typeHintReference) {
-            $php = $argument->isNullable() ? '?' : '';
 
-            if ($hint = $argument->getTypeHint()) {
-                $php .= $typeHintReference->isBuiltInParamTypeHint($hint) ? $hint : '\\'.$hint;
+            $type = $argument->getTypeNode();
+
+            if ($type->canUseNullShorthand()) {
+                $php = '?' . join('|', $type->getNonNullTypes());
+            }
+            else {
+                $php = join('|', $type->getTypes());
             }
 
             $php .= ' '.($argument->isPassedByReference() ? '&' : '');

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -238,17 +238,28 @@ class ClassMirror
 
     private function getTypeHints(ReflectionParameter $parameter) : array
     {
+        $types = [];
         $type = $parameter->getType();
 
         if ($type instanceof ReflectionNamedType) {
-            if ($type->getName() === 'self') {
-                return [$parameter->getDeclaringClass()->getName()];
-            }
-
-            return [$type->getName()];
+            $types = [$type->getName()];
+        }
+        elseif ($type instanceof ReflectionUnionType) {
+            $types = $type->getTypes();
         }
 
-        return [];
+        $types = array_map(
+            function(string $type) use ($parameter) {
+                if ($type === 'self') {
+                    return $parameter->getDeclaringClass()->getName();
+                }
+
+                return $type;
+            },
+            $types
+        );
+
+        return $types;
     }
 
     private function isNullable(ReflectionParameter $parameter)

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -191,6 +191,7 @@ class ClassMirror
         $node = new Node\ArgumentNode($name);
 
         $node->setTypeHint($this->getTypeHint($parameter));
+        $node->setAsNullable($this->isNullable($parameter));
 
         if ($parameter->isVariadic()) {
             $node->setAsVariadic();
@@ -204,7 +205,6 @@ class ClassMirror
             $node->setAsPassedByReference();
         }
 
-        $node->setAsNullable($this->isNullable($parameter));
 
         $methodNode->addArgument($node);
     }

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -11,6 +11,7 @@
 
 namespace Prophecy\Doubler\Generator;
 
+use Prophecy\Doubler\Generator\Node\ReturnTypeNode;
 use Prophecy\Exception\InvalidArgumentException;
 use Prophecy\Exception\Doubler\ClassMirrorException;
 use ReflectionClass;
@@ -154,11 +155,14 @@ class ClassMirror
                 $returnType = $method->getDeclaringClass()->getParentClass()->getName();
             }
 
-            $node->setReturnType($returnType);
+            $returnTypes = [$returnType];
 
             if ($method->getReturnType()->allowsNull()) {
-                $node->setNullableReturnType(true);
+                $returnTypes[] = 'null';
             }
+
+            $node->setReturnTypeNode(new ReturnTypeNode(...$returnTypes));
+
         }
 
         if (is_array($params = $method->getParameters()) && count($params)) {

--- a/src/Prophecy/Doubler/Generator/Node/ArgumentNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/ArgumentNode.php
@@ -19,12 +19,13 @@ namespace Prophecy\Doubler\Generator\Node;
 class ArgumentNode
 {
     private $name;
-    private $typeHint;
     private $default;
     private $optional    = false;
     private $byReference = false;
     private $isVariadic  = false;
-    private $isNullable  = false;
+
+    /** @var ArgumentTypeNode */
+    private $typeNode;
 
     /**
      * @param string $name
@@ -32,6 +33,7 @@ class ArgumentNode
     public function __construct($name)
     {
         $this->name = $name;
+        $this->typeNode = new ArgumentTypeNode();
     }
 
     public function getName()
@@ -39,14 +41,14 @@ class ArgumentNode
         return $this->name;
     }
 
-    public function getTypeHint()
+    public function setTypeNode(ArgumentTypeNode $typeNode)
     {
-        return $this->typeHint;
+        $this->typeNode = $typeNode;
     }
 
-    public function setTypeHint($typeHint = null)
+    public function getTypeNode() : ArgumentTypeNode
     {
-        $this->typeHint = $typeHint;
+        return $this->typeNode;
     }
 
     public function hasDefault()
@@ -90,13 +92,42 @@ class ArgumentNode
         return $this->isVariadic;
     }
 
-    public function isNullable()
+    /**
+     * @deprecated use getArgumentTypeNode instead
+     * @return string|null
+     */
+    public function getTypeHint()
     {
-        return $this->isNullable && $this->typeHint !== 'mixed';
+        $type = $this->typeNode->getNonNullTypes() ? $this->typeNode->getNonNullTypes()[0] : null;
+
+        return $type ? ltrim($type, '\\') : null;
     }
 
+    /**
+     * @deprecated use setArgumentTypeNode instead
+     * @param string|null $typeHint
+     */
+    public function setTypeHint($typeHint = null)
+    {
+        $this->typeNode = ($typeHint === null) ? new ArgumentTypeNode() : new ArgumentTypeNode($typeHint);
+    }
+
+    /**
+     * @deprecated use getArgumentTypeNode instead
+     * @return bool
+     */
+    public function isNullable()
+    {
+        return $this->typeNode->canUseNullShorthand();
+    }
+
+    /**
+     * @deprecated use getArgumentTypeNode instead
+     * @param bool $isNullable
+     */
     public function setAsNullable($isNullable = true)
     {
-        $this->isNullable = $isNullable;
+        $nonNullTypes = $this->typeNode->getNonNullTypes();
+        $this->typeNode = $isNullable ? new ArgumentTypeNode('null', ...$nonNullTypes) : new ArgumentTypeNode(...$nonNullTypes);
     }
 }

--- a/src/Prophecy/Doubler/Generator/Node/ArgumentTypeNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/ArgumentTypeNode.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Prophecy\Doubler\Generator\Node;
+
+use Prophecy\Exception\Doubler\DoubleException;
+
+class ArgumentTypeNode extends TypeNodeAbstract
+{
+
+}

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -43,6 +43,7 @@ class MethodNode
     {
         $this->name = $name;
         $this->code = $code;
+        $this->returnTypeNode = new ReturnTypeNode();
     }
 
     public function getVisibility()
@@ -113,6 +114,11 @@ class MethodNode
         return $this->returnTypeNode && $this->returnTypeNode->getNonNullTypes();
     }
 
+    public function setReturnTypeNode(ReturnTypeNode $returnTypeNode): void
+    {
+        $this->returnTypeNode = $returnTypeNode;
+    }
+
     /**
      * @deprecated use setReturnTypeNode instead
      * @param string $type
@@ -148,6 +154,11 @@ class MethodNode
         }
 
         return null;
+    }
+
+    public function getReturnTypeNode() : ReturnTypeNode
+    {
+        return $this->returnTypeNode;
     }
 
     /**

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -111,7 +111,7 @@ class MethodNode
      */
     public function hasReturnType()
     {
-        return $this->returnTypeNode && $this->returnTypeNode->getNonNullTypes();
+        return (bool) $this->returnTypeNode->getNonNullTypes();
     }
 
     public function setReturnTypeNode(ReturnTypeNode $returnTypeNode): void
@@ -148,7 +148,7 @@ class MethodNode
      */
     public function getReturnType()
     {
-        if ($this->returnTypeNode && $types = $this->returnTypeNode->getNonNullTypes())
+        if ($types = $this->returnTypeNode->getNonNullTypes())
         {
             return $types[0];
         }

--- a/src/Prophecy/Doubler/Generator/Node/MethodNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/MethodNode.php
@@ -106,7 +106,7 @@ class MethodNode
     }
 
     /**
-     * @deprecated
+     * @deprecated use getReturnTypeNode instead
      * @return bool
      */
     public function hasReturnType()
@@ -129,13 +129,13 @@ class MethodNode
     }
 
     /**
-     * @deprecated
+     * @deprecated use setReturnTypeNode instead
      * @param bool $bool
      */
     public function setNullableReturnType($bool = true)
     {
         if ($bool) {
-            $this->returnTypeNode = new ReturnTypeNode(...array_merge($this->returnTypeNode->getTypes(), ['null']));
+            $this->returnTypeNode = new ReturnTypeNode('null', ...$this->returnTypeNode->getTypes());
         }
         else {
             $this->returnTypeNode = new ReturnTypeNode(...$this->returnTypeNode->getNonNullTypes());
@@ -143,7 +143,7 @@ class MethodNode
     }
 
     /**
-     * @deprecated
+     * @deprecated use getReturnTypeNode instead
      * @return string|null
      */
     public function getReturnType()
@@ -162,7 +162,7 @@ class MethodNode
     }
 
     /**
-     * @deprecated
+     * @deprecated use getReturnTypeNode instead
      * @return bool
      */
     public function hasNullableReturnType()

--- a/src/Prophecy/Doubler/Generator/Node/ReturnTypeNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/ReturnTypeNode.php
@@ -91,4 +91,9 @@ final class ReturnTypeNode
     {
         return '\\' . ltrim('\\' . $type, '\\');
     }
+
+    public function isVoid(): bool
+    {
+        return $this->types == ['void' => 'void'];
+    }
 }

--- a/src/Prophecy/Doubler/Generator/Node/ReturnTypeNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/ReturnTypeNode.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Prophecy\Doubler\Generator\Node;
+
+use Prophecy\Exception\Doubler\DoubleException;
+
+final class ReturnTypeNode
+{
+    /** @var string[] */
+    private $types = [];
+
+    public function __construct(string ...$types)
+    {
+        foreach($types as $type) {
+            $type = $this->getRealType($type);
+            $this->types[$type] = $type;
+        }
+
+        $this->guardIsValidReturn();
+    }
+
+    private function getRealType(string $type): string
+    {
+        switch($type) {
+            // type aliases
+            case 'double':
+            case 'real':
+                return 'float';
+            case 'boolean':
+                return 'bool';
+            case 'integer':
+                return 'int';
+
+            //  built in types
+            case 'self':
+            case 'array':
+            case 'callable':
+            case 'bool':
+            case 'float':
+            case 'int':
+            case 'string':
+            case 'iterable':
+            case 'object':
+            case 'void':
+            case 'null':
+                return $type;
+            case 'mixed':
+                return PHP_VERSION_ID < 80000 ? $this->prefixWithNsSeparator($type) : $type;
+
+            default:
+                return $this->prefixWithNsSeparator($type);
+        }
+    }
+
+    private function guardIsValidReturn()
+    {
+        if ($this->types == ['null'=>'null']) {
+            throw new DoubleException('Return type cannot be standalone null');
+        }
+
+        if (isset($this->types['void']) && count($this->types) != 1) {
+            throw new DoubleException('void cannot be part of a union');
+        }
+
+        if (PHP_VERSION_ID >= 80000 && isset($this->types['mixed']) && count($this->types) != 1) {
+            throw new DoubleException('mixed cannot be part of a union');
+        }
+    }
+
+    public function getTypes() : array
+    {
+        return array_values($this->types);
+    }
+
+    public function canUseNullShorthand(): bool
+    {
+        return isset($this->types['null']) && count($this->types) <= 2;
+    }
+
+    public function getNonNullTypes(): array
+    {
+        return array_values(array_filter(
+            $this->types,
+            function(string $type) {
+                return $type != 'null';
+            }
+        ));
+    }
+
+    private function prefixWithNsSeparator(string $type): string
+    {
+        return '\\' . ltrim('\\' . $type, '\\');
+    }
+}

--- a/src/Prophecy/Doubler/Generator/Node/ReturnTypeNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/ReturnTypeNode.php
@@ -4,90 +4,24 @@ namespace Prophecy\Doubler\Generator\Node;
 
 use Prophecy\Exception\Doubler\DoubleException;
 
-final class ReturnTypeNode
+final class ReturnTypeNode extends TypeNodeAbstract
 {
-    /** @var string[] */
-    private $types = [];
-
-    public function __construct(string ...$types)
+    protected function getRealType(string $type): string
     {
-        foreach($types as $type) {
-            $type = $this->getRealType($type);
-            $this->types[$type] = $type;
+        if ($type == 'void') {
+            return $type;
         }
 
-        $this->guardIsValidReturn();
+        return parent::getRealType($type);
     }
 
-    private function getRealType(string $type): string
+    protected function guardIsValidType()
     {
-        switch($type) {
-            // type aliases
-            case 'double':
-            case 'real':
-                return 'float';
-            case 'boolean':
-                return 'bool';
-            case 'integer':
-                return 'int';
-
-            //  built in types
-            case 'self':
-            case 'array':
-            case 'callable':
-            case 'bool':
-            case 'float':
-            case 'int':
-            case 'string':
-            case 'iterable':
-            case 'object':
-            case 'void':
-            case 'null':
-                return $type;
-            case 'mixed':
-                return \PHP_VERSION_ID < 80000 ? $this->prefixWithNsSeparator($type) : $type;
-
-            default:
-                return $this->prefixWithNsSeparator($type);
-        }
-    }
-
-    private function guardIsValidReturn()
-    {
-        if ($this->types == ['null'=>'null']) {
-            throw new DoubleException('Return type cannot be standalone null');
-        }
-
         if (isset($this->types['void']) && count($this->types) !== 1) {
             throw new DoubleException('void cannot be part of a union');
         }
 
-        if (\PHP_VERSION_ID >= 80000 && isset($this->types['mixed']) && count($this->types) !== 1) {
-            throw new DoubleException('mixed cannot be part of a union');
-        }
-    }
-
-    public function getTypes() : array
-    {
-        return array_values($this->types);
-    }
-
-    public function canUseNullShorthand(): bool
-    {
-        return isset($this->types['null']) && count($this->types) <= 2;
-    }
-
-    public function getNonNullTypes(): array
-    {
-        $nonNullTypes = $this->types;
-        unset($nonNullTypes['null']);
-
-        return array_values($nonNullTypes);
-    }
-
-    private function prefixWithNsSeparator(string $type): string
-    {
-        return '\\' . ltrim($type, '\\');
+        parent::guardIsValidType();
     }
 
     public function isVoid(): bool

--- a/src/Prophecy/Doubler/Generator/Node/ReturnTypeNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/ReturnTypeNode.php
@@ -45,7 +45,7 @@ final class ReturnTypeNode
             case 'null':
                 return $type;
             case 'mixed':
-                return PHP_VERSION_ID < 80000 ? $this->prefixWithNsSeparator($type) : $type;
+                return \PHP_VERSION_ID < 80000 ? $this->prefixWithNsSeparator($type) : $type;
 
             default:
                 return $this->prefixWithNsSeparator($type);
@@ -62,7 +62,7 @@ final class ReturnTypeNode
             throw new DoubleException('void cannot be part of a union');
         }
 
-        if (PHP_VERSION_ID >= 80000 && isset($this->types['mixed']) && count($this->types) !== 1) {
+        if (\PHP_VERSION_ID >= 80000 && isset($this->types['mixed']) && count($this->types) !== 1) {
             throw new DoubleException('mixed cannot be part of a union');
         }
     }

--- a/src/Prophecy/Doubler/Generator/Node/ReturnTypeNode.php
+++ b/src/Prophecy/Doubler/Generator/Node/ReturnTypeNode.php
@@ -58,11 +58,11 @@ final class ReturnTypeNode
             throw new DoubleException('Return type cannot be standalone null');
         }
 
-        if (isset($this->types['void']) && count($this->types) != 1) {
+        if (isset($this->types['void']) && count($this->types) !== 1) {
             throw new DoubleException('void cannot be part of a union');
         }
 
-        if (PHP_VERSION_ID >= 80000 && isset($this->types['mixed']) && count($this->types) != 1) {
+        if (PHP_VERSION_ID >= 80000 && isset($this->types['mixed']) && count($this->types) !== 1) {
             throw new DoubleException('mixed cannot be part of a union');
         }
     }
@@ -79,17 +79,15 @@ final class ReturnTypeNode
 
     public function getNonNullTypes(): array
     {
-        return array_values(array_filter(
-            $this->types,
-            function(string $type) {
-                return $type != 'null';
-            }
-        ));
+        $nonNullTypes = $this->types;
+        unset($nonNullTypes['null']);
+
+        return array_values($nonNullTypes);
     }
 
     private function prefixWithNsSeparator(string $type): string
     {
-        return '\\' . ltrim('\\' . $type, '\\');
+        return '\\' . ltrim($type, '\\');
     }
 
     public function isVoid(): bool

--- a/src/Prophecy/Doubler/Generator/Node/TypeNodeAbstract.php
+++ b/src/Prophecy/Doubler/Generator/Node/TypeNodeAbstract.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Prophecy\Doubler\Generator\Node;
+
+use Prophecy\Exception\Doubler\DoubleException;
+
+abstract class TypeNodeAbstract
+{
+    /** @var string[] */
+    protected $types = [];
+
+    public function __construct(string ...$types)
+    {
+        foreach ($types as $type) {
+            $type = $this->getRealType($type);
+            $this->types[$type] = $type;
+        }
+
+        $this->guardIsValidType();
+    }
+
+    public function canUseNullShorthand(): bool
+    {
+        return isset($this->types['null']) && count($this->types) <= 2;
+    }
+
+    public function getTypes(): array
+    {
+        return array_values($this->types);
+    }
+
+    public function getNonNullTypes(): array
+    {
+        $nonNullTypes = $this->types;
+        unset($nonNullTypes['null']);
+
+        return array_values($nonNullTypes);
+    }
+
+    protected function prefixWithNsSeparator(string $type): string
+    {
+        return '\\' . ltrim($type, '\\');
+    }
+
+    protected function getRealType(string $type): string
+    {
+        switch ($type) {
+            // type aliases
+            case 'double':
+            case 'real':
+                return 'float';
+            case 'boolean':
+                return 'bool';
+            case 'integer':
+                return 'int';
+
+            //  built in types
+            case 'self':
+            case 'array':
+            case 'callable':
+            case 'bool':
+            case 'float':
+            case 'int':
+            case 'string':
+            case 'iterable':
+            case 'object':
+            case 'null':
+                return $type;
+            case 'mixed':
+                return \PHP_VERSION_ID < 80000 ? $this->prefixWithNsSeparator($type) : $type;
+
+            default:
+                return $this->prefixWithNsSeparator($type);
+        }
+    }
+
+    protected function guardIsValidType()
+    {
+        if ($this->types == ['null' => 'null']) {
+            throw new DoubleException('Argument type cannot be standalone null');
+        }
+
+        if (\PHP_VERSION_ID >= 80000 && isset($this->types['mixed']) && count($this->types) !== 1) {
+            throw new DoubleException('mixed cannot be part of a union');
+        }
+    }
+}

--- a/src/Prophecy/Doubler/Generator/TypeHintReference.php
+++ b/src/Prophecy/Doubler/Generator/TypeHintReference.php
@@ -5,6 +5,8 @@ namespace Prophecy\Doubler\Generator;
 /**
  * Tells whether a keyword refers to a class or to a built-in type for the
  * current version of php
+ *
+ * @deprecated in favour of Node\TypeNodeAbstract
  */
 final class TypeHintReference
 {

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -18,6 +18,7 @@ use Prophecy\Prediction;
 use Prophecy\Exception\Doubler\MethodNotFoundException;
 use Prophecy\Exception\InvalidArgumentException;
 use Prophecy\Exception\Prophecy\MethodProphecyException;
+use ReflectionNamedType;
 
 /**
  * Method prophecy.
@@ -70,7 +71,7 @@ class MethodProphecy
             $this->withArguments($arguments);
         }
 
-        if (true === $reflectedMethod->hasReturnType()) {
+        if (true === $reflectedMethod->hasReturnType() && $reflectedMethod->getReturnType() instanceof ReflectionNamedType) {
             $type = $reflectedMethod->getReturnType()->getName();
 
             if ('void' === $type) {

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -91,13 +91,30 @@ class MethodProphecy
 
             usort(
                 $types,
-                function(string $type) {
-                    if(class_exists($type) || interface_exists($type)) {
+                static function(string $type1, string $type2) {
+
+                    // null is lowest priority
+                    if ($type2 == 'null') {
                         return -1;
                     }
-                    if ($type == 'null') {
+                    elseif ($type1 == 'null') {
                         return 1;
                     }
+
+                    // objects are higher priority than scalars
+                    $isObject = static function($type) {
+                        return class_exists($type) || interface_exists($type);
+                    };
+
+                    if($isObject($type1) && !$isObject($type2)) {
+                        return -1;
+                    }
+                    elseif(!$isObject($type1) && $isObject($type2))
+                    {
+                        return 1;
+                    }
+
+                    // don't sort both-scalars or both-objects
                     return 0;
                 }
             );

--- a/tests/Doubler/Generator/ClassMirrorTest.php
+++ b/tests/Doubler/Generator/ClassMirrorTest.php
@@ -533,7 +533,7 @@ class ClassMirrorTest extends TestCase
         $classNode = (new ClassMirror())->reflect(new \ReflectionClass('Fixtures\Prophecy\UnionReturnTypes'), []);
         $methodNode = $classNode->getMethods()['doSomething'];
 
-        $this->assertSame('bool|\\stdClass', $methodNode->getArguments()[0]->getTypeHint());
+        $this->assertSame(['\stdClass', 'bool'], $methodNode->getReturnTypeNode()->getTypes());
     }
 
     /** @test */

--- a/tests/Doubler/Generator/ClassMirrorTest.php
+++ b/tests/Doubler/Generator/ClassMirrorTest.php
@@ -4,6 +4,7 @@ namespace Tests\Prophecy\Doubler\Generator;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Doubler\Generator\ClassMirror;
+use Prophecy\Doubler\Generator\Node\ArgumentTypeNode;
 use Prophecy\Doubler\Generator\Node\ReturnTypeNode;
 use Prophecy\Exception\Doubler\ClassMirrorException;
 use Prophecy\Exception\InvalidArgumentException;
@@ -78,7 +79,7 @@ class ClassMirrorTest extends TestCase
         $this->assertCount(1, $argNodes);
 
         $this->assertEquals('arg', $argNodes[0]->getName());
-        $this->assertNull($argNodes[0]->getTypeHint());
+        $this->assertEquals(new ArgumentTypeNode(), $argNodes[0]->getTypeNode());
         $this->assertFalse($argNodes[0]->isOptional());
         $this->assertNull($argNodes[0]->getDefault());
         $this->assertFalse($argNodes[0]->isPassedByReference());
@@ -102,18 +103,18 @@ class ClassMirrorTest extends TestCase
 
 
         $this->assertEquals('arg_1', $argNodes[0]->getName());
-        $this->assertEquals('ArrayAccess', $argNodes[0]->getTypeHint());
+        $this->assertEquals(new ArgumentTypeNode('ArrayAccess'), $argNodes[0]->getTypeNode());
         $this->assertFalse($argNodes[0]->isOptional());
 
         $this->assertEquals('arg_2', $argNodes[1]->getName());
-        $this->assertEquals('array', $argNodes[1]->getTypeHint());
+        $this->assertEquals(new ArgumentTypeNode('array'), $argNodes[1]->getTypeNode());
         $this->assertTrue($argNodes[1]->isOptional());
         $this->assertEquals(array(), $argNodes[1]->getDefault());
         $this->assertFalse($argNodes[1]->isPassedByReference());
         $this->assertFalse($argNodes[1]->isVariadic());
 
         $this->assertEquals('arg_3', $argNodes[2]->getName());
-        $this->assertEquals('ArrayAccess', $argNodes[2]->getTypeHint());
+        $this->assertEquals(new ArgumentTypeNode('ArrayAccess', 'null'), $argNodes[2]->getTypeNode());
         $this->assertTrue($argNodes[2]->isOptional());
         $this->assertNull($argNodes[2]->getDefault());
         $this->assertFalse($argNodes[2]->isPassedByReference());
@@ -137,13 +138,13 @@ class ClassMirrorTest extends TestCase
         $this->assertCount(2, $argNodes);
 
         $this->assertEquals('arg_1', $argNodes[0]->getName());
-        $this->assertEquals('callable', $argNodes[0]->getTypeHint());
+        $this->assertEquals(new ArgumentTypeNode('callable'), $argNodes[0]->getTypeNode());
         $this->assertFalse($argNodes[0]->isOptional());
         $this->assertFalse($argNodes[0]->isPassedByReference());
         $this->assertFalse($argNodes[0]->isVariadic());
 
         $this->assertEquals('arg_2', $argNodes[1]->getName());
-        $this->assertEquals('callable', $argNodes[1]->getTypeHint());
+        $this->assertEquals(new ArgumentTypeNode('callable', 'null'), $argNodes[1]->getTypeNode());
         $this->assertTrue($argNodes[1]->isOptional());
         $this->assertNull($argNodes[1]->getDefault());
         $this->assertFalse($argNodes[1]->isPassedByReference());
@@ -167,7 +168,7 @@ class ClassMirrorTest extends TestCase
         $this->assertCount(1, $argNodes);
 
         $this->assertEquals('args', $argNodes[0]->getName());
-        $this->assertNull($argNodes[0]->getTypeHint());
+        $this->assertEquals(new ArgumentTypeNode(), $argNodes[0]->getTypeNode());
         $this->assertFalse($argNodes[0]->isOptional());
         $this->assertFalse($argNodes[0]->isPassedByReference());
         $this->assertTrue($argNodes[0]->isVariadic());
@@ -194,7 +195,7 @@ class ClassMirrorTest extends TestCase
         $this->assertCount(1, $argNodes);
 
         $this->assertEquals('args', $argNodes[0]->getName());
-        $this->assertEquals('array', $argNodes[0]->getTypeHint());
+        $this->assertEquals(new ArgumentTypeNode('array'), $argNodes[0]->getTypeNode());
         $this->assertFalse($argNodes[0]->isOptional());
         $this->assertFalse($argNodes[0]->isPassedByReference());
         $this->assertTrue($argNodes[0]->isVariadic());
@@ -397,9 +398,9 @@ class ClassMirrorTest extends TestCase
         $method = $classNode->getMethod('export');
         $arguments = $method->getArguments();
 
-        $this->assertNull($arguments[0]->getTypeHint());
-        $this->assertNull($arguments[1]->getTypeHint());
-        $this->assertNull($arguments[2]->getTypeHint());
+        $this->assertEquals(new ArgumentTypeNode(), $arguments[0]->getTypeNode());
+        $this->assertEquals(new ArgumentTypeNode(), $arguments[1]->getTypeNode());
+        $this->assertEquals(new ArgumentTypeNode(), $arguments[2]->getTypeNode());
     }
 
     /**
@@ -412,7 +413,7 @@ class ClassMirrorTest extends TestCase
         $classNode = $mirror->reflect(new \ReflectionClass('Fixtures\Prophecy\OptionalDepsClass'), array());
         $method = $classNode->getMethod('iHaveAStrangeTypeHintedArg');
         $arguments = $method->getArguments();
-        $this->assertEquals('I\Simply\Am\Nonexistent', $arguments[0]->getTypeHint());
+        $this->assertEquals(new ArgumentTypeNode('I\Simply\Am\Nonexistent'), $arguments[0]->getTypeNode());
     }
 
     /**
@@ -426,8 +427,7 @@ class ClassMirrorTest extends TestCase
         $classNode = $mirror->reflect(new \ReflectionClass('Fixtures\Prophecy\NullableArrayParameter'), array());
         $method = $classNode->getMethod('iHaveNullableArrayParameterWithNotNullDefaultValue');
         $arguments = $method->getArguments();
-        $this->assertSame('array', $arguments[0]->getTypeHint());
-        $this->assertTrue($arguments[0]->isNullable());
+        $this->assertEquals(new ArgumentTypeNode('array', 'null'), $arguments[0]->getTypeNode());
     }
 
     /**
@@ -440,7 +440,7 @@ class ClassMirrorTest extends TestCase
         $classNode = $mirror->reflect(new \ReflectionClass('Fixtures\Prophecy\OptionalDepsClass'), array());
         $method = $classNode->getMethod('iHaveAnEvenStrangerTypeHintedArg');
         $arguments = $method->getArguments();
-        $this->assertEquals('I\Simply\Am\Not', $arguments[0]->getTypeHint());
+        $this->assertEquals(new ArgumentTypeNode('I\Simply\Am\Not'), $arguments[0]->getTypeNode());
     }
 
     /**
@@ -546,7 +546,7 @@ class ClassMirrorTest extends TestCase
         $classNode = (new ClassMirror())->reflect(new \ReflectionClass('Fixtures\Prophecy\UnionArgumentTypes'), []);
         $methodNode = $classNode->getMethods()['doSomething'];
 
-        $this->assertSame('bool|\\stdClass', $methodNode->getArguments()[0]->getTypeHint());
+        $this->assertEquals(new ArgumentTypeNode('bool', '\\stdClass'), $methodNode->getArguments()[0]->getTypeNode());
     }
 
     /**

--- a/tests/Doubler/Generator/ClassMirrorTest.php
+++ b/tests/Doubler/Generator/ClassMirrorTest.php
@@ -4,6 +4,7 @@ namespace Tests\Prophecy\Doubler\Generator;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Doubler\Generator\ClassMirror;
+use Prophecy\Doubler\Generator\Node\ReturnTypeNode;
 use Prophecy\Exception\Doubler\ClassMirrorException;
 use Prophecy\Exception\InvalidArgumentException;
 
@@ -350,9 +351,9 @@ class ClassMirrorTest extends TestCase
         $this->assertTrue($classNode->hasMethod('getSelf'));
         $this->assertTrue($classNode->hasMethod('getParent'));
 
-        $this->assertEquals('string', $classNode->getMethod('getName')->getReturnType());
-        $this->assertEquals('\Fixtures\Prophecy\WithReturnTypehints', $classNode->getMethod('getSelf')->getReturnType());
-        $this->assertEquals('\Fixtures\Prophecy\EmptyClass', $classNode->getMethod('getParent')->getReturnType());
+        $this->assertEquals(new ReturnTypeNode('string'), $classNode->getMethod('getName')->getReturnTypeNode());
+        $this->assertEquals(new ReturnTypeNode('\Fixtures\Prophecy\WithReturnTypehints'), $classNode->getMethod('getSelf')->getReturnTypeNode());
+        $this->assertEquals(new ReturnTypeNode('\Fixtures\Prophecy\EmptyClass'), $classNode->getMethod('getParent')->getReturnTypeNode());
     }
 
     /**

--- a/tests/Doubler/Generator/ClassMirrorTest.php
+++ b/tests/Doubler/Generator/ClassMirrorTest.php
@@ -494,10 +494,7 @@ class ClassMirrorTest extends TestCase
         $method->isProtected()->willReturn(false);
         $method->isStatic()->willReturn(false);
         $method->returnsReference()->willReturn(false);
-
-        if (version_compare(PHP_VERSION, '7.0', '>=')) {
-            $method->hasReturnType()->willReturn(false);
-        }
+        $method->hasReturnType()->willReturn(false);
 
         $parameter->getName()->willReturn('...');
         $parameter->isDefaultValueAvailable()->willReturn(true);
@@ -507,9 +504,8 @@ class ClassMirrorTest extends TestCase
         $parameter->getClass()->willReturn($class);
         $parameter->getType()->willReturn(null);
         $parameter->hasType()->willReturn(false);
-        if (version_compare(PHP_VERSION, '5.6', '>=')) {
-            $parameter->isVariadic()->willReturn(false);
-        }
+        $parameter->isVariadic()->willReturn(false);
+        $parameter->getDeclaringClass()->willReturn($class);
 
         $mirror = new ClassMirror();
 
@@ -548,6 +544,21 @@ class ClassMirrorTest extends TestCase
 
         $this->assertEquals(new ArgumentTypeNode('bool', '\\stdClass'), $methodNode->getArguments()[0]->getTypeNode());
     }
+
+    /** @test */
+    public function it_can_double_a_class_with_mixed_types()
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('Mixed type is not supported in this PHP version');
+        }
+
+        $classNode = (new ClassMirror())->reflect(new \ReflectionClass('Fixtures\Prophecy\MixedTypes'), []);
+        $methodNode = $classNode->getMethods()['doSomething'];
+
+        $this->assertEquals(new ArgumentTypeNode('mixed'), $methodNode->getArguments()[0]->getTypeNode());
+        $this->assertEquals(new ReturnTypeNode('mixed'), $methodNode->getReturnTypeNode());
+    }
+
 
     /**
      * @test


### PR DESCRIPTION
Resolves #482

This pushes the types logic from the ArgumentNode and MethodNode (and the TypeHintReference) down into smaller value objects for ArgumentTypeNode and ReturnTypeNodes, and then expands it to support Unions