### PR TITLE
Fix PHP 8 issue with Named Arguments in array_merge

### DIFF
--- a/src/Prophecy/Call/CallCenter.php
+++ b/src/Prophecy/Call/CallCenter.php
@@ -176,7 +176,7 @@ class CallCenter
 
         $expected = array();
 
-        foreach (call_user_func_array('array_merge', $prophecy->getMethodProphecies()) as $methodProphecy) {
+        foreach (call_user_func_array('array_merge', array_values($prophecy->getMethodProphecies())) as $methodProphecy) {
             $expected[] = sprintf(
                 "  - %s(\n" .
                 "%s\n" .


### PR DESCRIPTION
For example, see https://github.com/composer/composer/pull/9076