### PR TITLE
Fix issue caused by named arguments

### DIFF
--- a/src/Prophecy/Call/CallCenter.php
+++ b/src/Prophecy/Call/CallCenter.php
@@ -176,7 +176,7 @@ class CallCenter
 
         $expected = array();
 
-        foreach (call_user_func_array('array_merge', $prophecy->getMethodProphecies()) as $methodProphecy) {
+        foreach (array_merge(...array_values($prophecy->getMethodProphecies())) as $methodProphecy) {
             $expected[] = sprintf(
                 "  - %s(\n" .
                 "%s\n" .


### PR DESCRIPTION
Because the array has keys, we get an error