### PR TITLE
Force a specific phpspec hash until it has a PHP8 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,8 @@ matrix:
     - php: 7.4
       dist: bionic
     - php: nightly
-      env: COMPOSER_FLAGS='--ignore-platform-reqs'
-    - php: nightly
       env: COMPOSER_FLAGS='--ignore-platform-reqs' COMPOSER_FORCE='phpspec/phpspec dev-master#5c6b6a5737420af057170b246ba9941acaa11614'
   fast_finish: true
-  allow_failures:
-    - php: nightly
 
 install:
   - export COMPOSER_ROOT_VERSION=dev-master


### PR DESCRIPTION
Pins to a known good PHP8-supporting phpspec

Also stops nightly build from being an allowed failure. If we merge this, #499 and #495 we should have a passing PHP8 build