### PR TITLE
Problem with inherited self return types

### DIFF
--- a/fixtures/AbstractBaseClassWithMethodWithReturnType.php
+++ b/fixtures/AbstractBaseClassWithMethodWithReturnType.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Prophecy;
+
+abstract class AbstractBaseClassWithMethodWithReturnType implements EmptyInterface
+{
+    private $test;
+
+    public function test(?\DateTimeInterface $test): self
+    {
+        $this->test = $test;
+
+        return $this;
+    }
+}

--- a/fixtures/ClassExtendAbstractWithMethodWithReturnType.php
+++ b/fixtures/ClassExtendAbstractWithMethodWithReturnType.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Prophecy;
+
+class ClassExtendAbstractWithMethodWithReturnType extends AbstractBaseClassWithMethodWithReturnType
+{
+
+}

--- a/tests/ProphetTest.php
+++ b/tests/ProphetTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Prophecy;
+
+use Fixtures\Prophecy\ClassExtendAbstractWithMethodWithReturnType;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophet;
+
+class ProphetTest extends TestCase
+{
+    public function testToDoAProhecy()
+    {
+        $prophet = new Prophet();
+
+        $a = $prophet->prophesize(ClassExtendAbstractWithMethodWithReturnType::class);
+        $realObj = $a->reveal();
+    }
+}


### PR DESCRIPTION
I have this behavior with the new minor version, maybe is a bug.

When I do a prophecy of an extended class that inherits a method with `self` return type I've this error:
```
Fatal error: Declaration of Double\Fixtures\Prophecy\ClassExtendAbstractWithMethodWithReturnType\P6::test(?DateTimeInterface $test = NULL): Fixtures\Prophecy\ClassExtendAbstractWithMethodWithReturnType must be compatible with Fixtures\Prophecy\AbstractBaseClassWithMethodWithReturnType::test(?DateTimeInterface $test): Fixtures\Prophecy\AbstractBaseClassWithMethodWithReturnType in /home/travis/build/giovannialbero1992/prophecy/src/Prophecy/Doubler/Generator/ClassCreator.php(49) : eval()'d code on line 2
```
This error is raised into PHP versions <=7.3 