### PR TITLE
imp: willYield handle Generator::getReturn()

### DIFF
--- a/spec/Prophecy/Prophecy/MethodProphecySpec.php
+++ b/spec/Prophecy/Prophecy/MethodProphecySpec.php
@@ -156,6 +156,16 @@ class MethodProphecySpec extends ObjectBehavior
         $this->getPromise()->execute(array(), $objectProphecy, $this)->shouldYield(array(10 => 'foo', 11 => 'bar'));
     }
 
+    function it_yields_and_return_elements_configured_in_willYield(ObjectProphecy $objectProphecy)
+    {
+        $objectProphecy->addMethodProphecy($this)->willReturn(null);
+
+        $this->willYield(array('foo', 'bar'), true);
+        $generator = $this->getPromise()->execute(array(), $objectProphecy, $this);
+        $generator->shouldYield(array('foo', 'bar'));
+        $generator->callOnWrappedObject('getReturn')->shouldReturn(true);
+    }
+
     function it_adds_ThrowPromise_during_willThrow_call(ObjectProphecy $objectProphecy)
     {
         $objectProphecy->addMethodProphecy($this)->willReturn(null);

--- a/src/Prophecy/Prophecy/MethodProphecy.php
+++ b/src/Prophecy/Prophecy/MethodProphecy.php
@@ -227,12 +227,13 @@ class MethodProphecy
 
     /**
      * @param array $items
+     * @param mixed $return
      *
      * @return $this
      *
      * @throws \Prophecy\Exception\InvalidArgumentException
      */
-    public function willYield($items)
+    public function willYield($items, $return = null)
     {
         if ($this->voidReturnType) {
             throw new MethodProphecyException(
@@ -248,10 +249,10 @@ class MethodProphecy
             ));
         }
 
-        $generator =  function() use ($items) {
-            foreach ($items as $key => $value) {
-                yield $key => $value;
-            }
+        $generator =  function() use ($items, $return) {
+            yield from $items;
+
+            return $return;
         };
 
         return $this->will($generator);


### PR DESCRIPTION
The current implementation of `MethodProphecy::willYield()` does not allow to specify a return value for the mocked generator.

The proposal here is to add an optional parameter allowing to define the return value:
```php
$prophecy->createGenerator()->willYield(['foo', 'bar'], 'return value');
```