### PR TITLE
Current phpspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,10 @@ matrix:
     - php: 7.4
       dist: bionic
     - php: nightly
-      env: COMPOSER_FLAGS='--ignore-platform-reqs' COMPOSER_FORCE='phpspec/phpspec dev-master#5c6b6a5737420af057170b246ba9941acaa11614'
   fast_finish: true
 
 install:
   - export COMPOSER_ROOT_VERSION=dev-master
-  - if [ -n "$COMPOSER_FORCE" ]; then composer require $COMPOSER_FORCE --no-update ; fi;
   - if [ "$DEPENDENCIES" != "low" ]; then composer update $COMPOSER_FLAGS; fi;
   - if [ "$DEPENDENCIES" == "low" ]; then composer update $COMPOSER_FLAGS --prefer-lowest; fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
   include:
     - php: 7.2
       dist: bionic
-      env: DEPENDENCIES='low'
+      env: COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.2
       dist: bionic
     - php: 7.3
@@ -26,8 +26,7 @@ matrix:
 
 install:
   - export COMPOSER_ROOT_VERSION=dev-master
-  - if [ "$DEPENDENCIES" != "low" ]; then composer update $COMPOSER_FLAGS; fi;
-  - if [ "$DEPENDENCIES" == "low" ]; then composer update $COMPOSER_FLAGS --prefer-lowest; fi;
+  - composer update $COMPOSER_FLAGS
 
 script:
   - vendor/bin/phpspec run -fpretty -v

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 
     "require-dev": {
         "phpspec/phpspec": "^6.0",
-        "phpunit/phpunit": "^8.0 || ^9.0 <9.3"
+        "phpunit/phpunit": "^8.0 || ^9.0"
     },
 
     "autoload": {


### PR DESCRIPTION
We were pinning to a specific phpspec hash but now 6.3.0 is released we can do a normal install instead