### PR TITLE
Make two minor grammar updates to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $prophecy->willImplement('SessionHandlerInterface');
 ```
 
 There are 2 interesting calls - `willExtend` and `willImplement`. The first one tells
-object prophecy that our object should extend specific class, the second one says that
+object prophecy that our object should extend a specific class. The second one says that
 it should implement some interface. Obviously, objects in PHP can implement multiple
 interfaces, but extend only one parent class.
 


### PR DESCRIPTION
While reading through the project README on github.com, I noticed a small grammar mistake in it, and wanted to fix it. While making that fix, I made a further slight change to the containing sentence to improve the readability that much more. Nothing major. Just trying to help where I can.