### PR TITLE
Fix the class attached to methodnotfoundexception

### DIFF
--- a/src/Prophecy/Doubler/ClassPatch/ProphecySubjectPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/ProphecySubjectPatch.php
@@ -92,7 +92,7 @@ PHP
         $__call->setCode(<<<PHP
 throw new \Prophecy\Exception\Doubler\MethodNotFoundException(
     sprintf('Method `%s::%s()` not found.', get_class(\$this), func_get_arg(0)),
-    \$this->getProphecy(), func_get_arg(0)
+    get_class(\$this), func_get_arg(0)
 );
 PHP
         );


### PR DESCRIPTION
The class was always being set to ObjectProphecy, which causes issues when trying to work out which class the method was not found on

An alternative would have been to use `$this->getProphecy()->reveal()` but that may cause side effects

Fixing this resolves https://github.com/phpspec/phpspec/issues/1350