### PR TITLE
Add .github directory to .gitattributes export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,9 @@
-/.gitattributes export-ignore
-/.gitignore export-ignore
-/.travis.yml export-ignore
-/CONTRIBUTING.md export-ignore
-/fixtures/ export-ignore
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/.travis.yml      export-ignore
+/CONTRIBUTING.md  export-ignore
+/.github/         export-ignore
+/fixtures/        export-ignore
 /phpunit.xml.dist export-ignore
-/spec/ export-ignore
-/tests/ export-ignore
+/spec/            export-ignore
+/tests/           export-ignore


### PR DESCRIPTION
Add `.github` to `.gitattributes` with an `export-ignore` rule. This also aligns the `export-ignore` rules for more readability.