### PR TITLE
Fix return type error for unexpected method calls

### DIFF
--- a/src/Prophecy/Call/CallCenter.php
+++ b/src/Prophecy/Call/CallCenter.php
@@ -12,6 +12,7 @@
 namespace Prophecy\Call;
 
 use Prophecy\Exception\Prophecy\MethodProphecyException;
+use Prophecy\Prophecy\MethodProphecy;
 use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\Argument\ArgumentsWildcard;
 use Prophecy\Util\StringUtil;
@@ -81,12 +82,10 @@ class CallCenter
         // There are method prophecies, so it's a fake/stub. Searching prophecy for this call
         $matches = $this->findMethodProphecies($prophecy, $methodName, $arguments);
 
-        // If fake/stub doesn't have method prophecy for this call - throw exception
+        // If fake/stub doesn't have method prophecy for this call - remember it as unexpected method call
         if (!count($matches)) {
             $this->unexpectedCalls->attach(new Call($methodName, $arguments, null, null, $file, $line), $prophecy);
-            $this->recordedCalls[] = new Call($methodName, $arguments, null, null, $file, $line);
-
-            return null;
+            $matches = [[1, new MethodProphecy($prophecy, $methodName, $arguments)]];
         }
 
         // Sort matches by their score value


### PR DESCRIPTION
*Problem*

This PR attempts to fix the issue of triggering a type error when an unexpected method call happens. Now it will return the correct type and let the code execution finish, so the predictions can be evaluated at the end of the test run.
See related comment here: https://github.com/phpspec/prophecy/pull/441#discussion_r388191626
PR which introduced the issue: https://github.com/phpspec/prophecy/pull/441
Relevant GitHub issues:
- https://github.com/phpspec/prophecy/issues/120
- https://github.com/phpspec/prophecy/issues/472

*Example - Classes to test*
```
<?php

namespace Tkotosz\TestProject;

class Foo
{
    public function doStuff(Bar $bar)
    {
        $x = $bar->aaa();
        $bar->bbb($x+4);
    }
}
```
```
<?php

namespace Tkotosz\TestProject;

class Bar
{
    public function aaa(): int
    {
        return 42;
    }

    public function bbb(int $x): int
    {
        return $x+1;
    }
}
```

*Example - spec 1*
```
<?php

namespace spec\Tkotosz\TestProject;

use PhpSpec\ObjectBehavior;
use Tkotosz\TestProject\Foo;
use Tkotosz\TestProject\Bar;

class FooSpec extends ObjectBehavior
{
    function it_test_1(Bar $time)
    {
        $time->aaa()->willReturn(22);

        $this->doStuff($time);

        $time->bbb(22+4)->shouldHaveBeenCalled();
    }
}
```
The test passes: The only expectation we have is that method `bbb` should have been called with 26 and that happened so everything is fine.
Note: This works with using `shouldBeCalled` before `doStuff` as well.

*Example - spec 2*
```
<?php

namespace spec\Tkotosz\TestProject;

use PhpSpec\ObjectBehavior;
use Tkotosz\TestProject\Foo;
use Tkotosz\TestProject\Bar;

class FooSpec extends ObjectBehavior
{
    function it_test_2(Bar $time)
    {
        $time->aaa()->willReturn(22);

        $this->doStuff($time);

        $time->bbb(22+4)->shouldNotHaveBeenCalled();
    }
}
```
The test fails: The only expectation we have is that method `bbb` should NOT have been called with 26 and that happened so the test fails. (This also works using Argument::any() in the prediction)
Note: This works with using `shouldNotBeCalled` before `doStuff` as well.

*Example - spec 3*
```
<?php

namespace spec\Tkotosz\TestProject;

use PhpSpec\ObjectBehavior;
use Tkotosz\TestProject\Foo;
use Tkotosz\TestProject\Bar;

class FooSpec extends ObjectBehavior
{
    function it_test_3(Bar $time)
    {
        $time->aaa()->willReturn(22);

        $this->doStuff($time);
    }
}
```
The test passes: There are no expectations so there is nothing that could fail here. So now the call to the method `bbb` is completely ignored, still not reported as an unexpected call. I am not sure if this is the desired behavior :thinking: since this basically eliminates the unexpected method call errors entirely. You will only see errors if you have a failed expectation.

