### PR TITLE
Support arguments on virtual magic methods

### DIFF
--- a/fixtures/WithPhpdocClass.php
+++ b/fixtures/WithPhpdocClass.php
@@ -1,12 +1,11 @@
 <?php
 
-
 namespace Fixtures\Prophecy;
-
 
 /**
  * @method string name(string $gender = null)
  * @method mixed randomElement(array $array = array('a', 'b', 'c'))
+ * @method mixed __unserialize($data)
  */
 class WithPhpdocClass
 {

--- a/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php
@@ -11,6 +11,7 @@
 
 namespace Prophecy\Doubler\ClassPatch;
 
+use Prophecy\Doubler\Generator\Node\ArgumentNode;
 use Prophecy\Doubler\Generator\Node\ClassNode;
 use Prophecy\Doubler\Generator\Node\MethodNode;
 use Prophecy\PhpDocumentor\ClassAndInterfaceTagRetriever;
@@ -25,6 +26,8 @@ use Prophecy\PhpDocumentor\MethodTagRetrieverInterface;
  */
 class MagicCallPatch implements ClassPatchInterface
 {
+    const MAGIC_METHODS_WITH_ARGUMENTS = ['__call', '__callStatic', '__get', '__isset', '__set', '__set_state', '__unserialize', '__unset'];
+
     private $tagRetriever;
 
     public function __construct(MethodTagRetrieverInterface $tagRetriever = null)
@@ -71,6 +74,15 @@ class MagicCallPatch implements ClassPatchInterface
 
                     if (!$reflectionClass->hasMethod($methodName)) {
                         $methodNode = new MethodNode($methodName);
+
+                        // only magic methods can have a contract that needs to be enforced
+                        if (in_array($methodName, self::MAGIC_METHODS_WITH_ARGUMENTS)) {
+                            foreach($tag->getArguments() as $argument) {
+                                $argumentNode = new ArgumentNode($argument['name']);
+                                $methodNode->addArgument($argumentNode);
+                            }
+                        }
+
                         $methodNode->setStatic($tag->isStatic());
                         $node->addMethod($methodNode);
                     }
@@ -91,4 +103,3 @@ class MagicCallPatch implements ClassPatchInterface
         return 50;
     }
 }
-

--- a/tests/Doubler/ClassPatch/MagicCallPatchTest.php
+++ b/tests/Doubler/ClassPatch/MagicCallPatchTest.php
@@ -5,6 +5,8 @@ namespace Tests\Prophecy\Doubler\ClassPatch;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Doubler\ClassPatch\MagicCallPatch;
 use Prophecy\Doubler\Generator\ClassMirror;
+use Prophecy\Doubler\Generator\Node\ArgumentNode;
+use Prophecy\Doubler\Generator\Node\ClassNode;
 
 class MagicCallPatchTest extends TestCase
 {
@@ -15,12 +17,7 @@ class MagicCallPatchTest extends TestCase
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\WithPhpdocClass');
 
-        $mirror = new ClassMirror();
-        $classNode = $mirror->reflect($class, array());
-
-        $patch = new MagicCallPatch();
-
-        $patch->apply($classNode);
+        $classNode = $this->applyPatchTo($class);
 
         // Newer phpDocumentor versions allow reading valid method tags, even when some other tags are invalid
         // Some older versions might also have this method due to not considering the method tag invalid as rule evolved, but we don't track that.
@@ -30,5 +27,28 @@ class MagicCallPatchTest extends TestCase
 
         // We expect no error when processing the class patch. But we still need to increment the assertion count.
         $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    public function it_supports_arguments_for_magic_methods()
+    {
+        $class = new \ReflectionClass('Fixtures\Prophecy\WithPhpdocClass');
+
+        $classNode = $this->applyPatchTo($class);
+
+        $this->assertEquals([new ArgumentNode('data')], $classNode->getMethod('__unserialize')->getArguments());
+    }
+
+    private function applyPatchTo(\ReflectionClass $class): ClassNode
+    {
+        $mirror = new ClassMirror();
+        $classNode = $mirror->reflect($class, array());
+
+        $patch = new MagicCallPatch();
+
+        $patch->apply($classNode);
+        return $classNode;
     }
 }


### PR DESCRIPTION
Previously we didn't generate any arguments at all when looking at @method annotations. This was ok in the majority of cases because there was no contract that could apply to them (e.g. no interface can force a @method annotation)

Since PHP 8.0, certain magic methods now have their signatures enforced (https://wiki.php.net/rfc/magic-methods-signature)

We still don't need to generate types, but the number of arguments now needs to be correct.

Fixes #520 