### PR TITLE
Normalise Licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Copyright (c) 2013 Konstantin Kudryashov <ever.zet@gmail.com>
-                   Marcello Duarte <marcello.duarte@gmail.com>
+Copyright (c) 2013 Marcello Duarte <marcello.duarte@gmail.com>
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation


### PR DESCRIPTION
Currently Github doesn't know what the licence is, this change allows Github to pick up the licence