### PR TITLE
Fix branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "1.11.x-dev"
+            "dev-master": "1.x-dev"
         }
     }
 }


### PR DESCRIPTION
Because the composer.json file of the master branch tells Composer that `master` contains versions `1.11.x-dev`, Composer believes that the master branch is behind the current release 1.13.0.

<img width="302" alt="Bildschirmfoto 2021-08-18 um 19 12 29" src="https://user-images.githubusercontent.com/1506493/129942423-6ddfc6d0-169e-4429-8d5f-d27483123414.png">

This PR proposes to change the alias to `1.x-dev` which would tell Composer that the master branch is always ahead of any tagged 1.x release. This would remove the need of regularly bumping that setting. I also believe that the proposed setting reflects the current development workflow on this repository better.