### PR TITLE
Test that doubling an Enum causes a sensible error

### DIFF
--- a/fixtures/Enum.php
+++ b/fixtures/Enum.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Fixtures\Prophecy;
+
+enum Enum {
+    case Clubs;
+    case Diamonds;
+    case Hearts;
+    case Spades;
+}

--- a/tests/Doubler/Generator/ClassMirrorTest.php
+++ b/tests/Doubler/Generator/ClassMirrorTest.php
@@ -603,4 +603,19 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ReturnTypeNode('never'), $methodNode->getReturnTypeNode());
 
     }
+
+    /**
+     * @test
+     */
+    public function it_can_not_double_an_enum()
+    {
+        if (PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Enums are not supported in this PHP version');
+        }
+
+        $this->expectException(ClassMirrorException::class);
+
+        $classNode = (new ClassMirror())->reflect(new \ReflectionClass('Fixtures\Prophecy\Enum'), []);
+
+    }
 }


### PR DESCRIPTION
Just checks that it's a ClassMirrorException rather than some other fatal

Fixes #536