### PR TITLE
Disallow intersection types with a nicer error message

### DIFF
--- a/fixtures/IntersectionArgumentType.php
+++ b/fixtures/IntersectionArgumentType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Fixtures\Prophecy;
+
+class IntersectionArgumentType
+{
+    public function doSomething (Bar&Baz $foo)
+    {
+
+    }
+}

--- a/fixtures/IntersectionReturnType.php
+++ b/fixtures/IntersectionReturnType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Fixtures\Prophecy;
+
+class IntersectionReturnType
+{
+    public function doSomething () : Bar&Baz
+    {
+
+    }
+}

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -16,6 +16,7 @@ use Prophecy\Doubler\Generator\Node\ReturnTypeNode;
 use Prophecy\Exception\InvalidArgumentException;
 use Prophecy\Exception\Doubler\ClassMirrorException;
 use ReflectionClass;
+use ReflectionIntersectionType;
 use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionParameter;
@@ -222,6 +223,12 @@ class ClassMirror
         }
         elseif ($type instanceof ReflectionUnionType) {
             $types = $type->getTypes();
+        }
+        elseif ($type instanceof ReflectionIntersectionType) {
+            throw new ClassMirrorException('Doubling intersection types is not supported', $class);
+        }
+        elseif(is_object($type)) {
+            throw new ClassMirrorException('Unknown reflection type ' . get_class($type), $class);
         }
 
         $types = array_map(

--- a/tests/Doubler/Generator/ClassMirrorTest.php
+++ b/tests/Doubler/Generator/ClassMirrorTest.php
@@ -603,4 +603,32 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ReturnTypeNode('never'), $methodNode->getReturnTypeNode());
 
     }
+
+    /**
+     * @test
+     */
+    public function it_can_not_double_intersection_return_types()
+    {
+        if (PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Intersection types are not supported in this PHP version');
+        }
+
+        $this->expectException(ClassMirrorException::class);
+
+        $classNode = (new ClassMirror())->reflect(new \ReflectionClass('Fixtures\Prophecy\IntersectionReturnType'), []);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_not_double_intersection_argument_types()
+    {
+        if (PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Intersection types are not supported in this PHP version');
+        }
+
+        $this->expectException(ClassMirrorException::class);
+
+        $classNode = (new ClassMirror())->reflect(new \ReflectionClass('Fixtures\Prophecy\IntersectionArgumentType'), []);
+    }
 }


### PR DESCRIPTION
Does not really address #535 but makes doubling an intersection type produce a sensible error message, so unblocks an 8.1-supporting release