### PR TITLE
Fix #332: Calling original method is unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,3 +402,10 @@ $em->flush()->shouldHaveBeenCalled();
 ```
 
 Such manipulation with doubles is called spying. And with Prophecy it just works.
+
+
+## FAQ
+
+### Can I call the original methods on a prophesized class?
+
+Prophecy does not support calling the original methods on a phrophesized class. If you find yourself needing to mock some methods of a class while calling the original version of other methods, it's likely a sign that your class violates the [single-responsibility principle](https://en.wikipedia.org/wiki/Single-responsibility_principle) and should be refactored.


### PR DESCRIPTION
Fixes #332. This use case is explicitly unsupported, so let's document it to avoid further confusion.