### PR TITLE
Add return types in comparator classes

### DIFF
--- a/src/Prophecy/Comparator/ClosureComparator.php
+++ b/src/Prophecy/Comparator/ClosureComparator.php
@@ -21,13 +21,13 @@ use SebastianBergmann\Comparator\ComparisonFailure;
  */
 final class ClosureComparator extends Comparator
 {
-    public function accepts($expected, $actual)
+    public function accepts($expected, $actual): bool
     {
         return is_object($expected) && $expected instanceof \Closure
             && is_object($actual) && $actual instanceof \Closure;
     }
 
-    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false, array &$processed = array())
+    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false, array &$processed = array()): void
     {
         if ($expected !== $actual) {
             throw new ComparisonFailure(

--- a/src/Prophecy/Comparator/ProphecyComparator.php
+++ b/src/Prophecy/Comparator/ProphecyComparator.php
@@ -14,14 +14,17 @@ namespace Prophecy\Comparator;
 use Prophecy\Prophecy\ProphecyInterface;
 use SebastianBergmann\Comparator\ObjectComparator;
 
+/**
+ * @final
+ */
 class ProphecyComparator extends ObjectComparator
 {
-    public function accepts($expected, $actual)
+    public function accepts($expected, $actual): bool
     {
         return is_object($expected) && is_object($actual) && $actual instanceof ProphecyInterface;
     }
 
-    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false, array &$processed = array())
+    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false, array &$processed = array()): void
     {
         parent::assertEquals($expected, $actual->reveal(), $delta, $canonicalize, $ignoreCase, $processed);
     }


### PR DESCRIPTION
This avoids deprecations reported by Symfony's DebugClassLoader saying that `Comparator` might add a return type in a future version. The other way to opt-out of the deprecation would be to add a `@return` phpdoc, but given we only supports PHP 7.2+ that has partial covariance for return types, it is OK to add the types natively.