### PR TITLE
Switch from ClassName:spl_object_hash to ClassName#id

### DIFF
--- a/spec/Prophecy/Argument/ArgumentsWildcardSpec.php
+++ b/spec/Prophecy/Argument/ArgumentsWildcardSpec.php
@@ -12,12 +12,12 @@ class ArgumentsWildcardSpec extends ObjectBehavior
         $this->beConstructedWith(array(42, 'zet', $object));
 
         $class = get_class($object->getWrappedObject());
-        $hash  = spl_object_hash($object->getWrappedObject());
+        $id  = spl_object_id($object->getWrappedObject());
 
-        $objHash = "exact(42), exact(\"zet\"), exact($class:$hash Object (\n    'objectProphecyClosure' => Closure:%s Object (\n        0 => Closure:%s Object\n    )\n))";
+        $objHash = "exact(42), exact(\"zet\"), exact($class#$id Object (\n    'objectProphecyClosure' => Closure#%s Object (\n        0 => Closure#%s Object\n    )\n))";
 
-        $hashRegexExpr = '[a-f0-9]{32}';
-        $this->__toString()->shouldMatch(sprintf('/^%s$/', sprintf(preg_quote("$objHash"), $hashRegexExpr, $hashRegexExpr)));
+        $idRegexExpr = '[0-9]+';
+        $this->__toString()->shouldMatch(sprintf('/^%s$/', sprintf(preg_quote("$objHash"), $idRegexExpr, $idRegexExpr)));
     }
 
     function it_generates_string_representation_from_all_tokens_imploded(

--- a/spec/Prophecy/Argument/Token/ExactValueTokenSpec.php
+++ b/spec/Prophecy/Argument/Token/ExactValueTokenSpec.php
@@ -133,15 +133,15 @@ class ExactValueTokenSpec extends ObjectBehavior
 
     function it_generates_proper_string_representation_for_object(\stdClass $object)
     {
-        $objHash = sprintf('exact(%s:%s',
+        $objHash = sprintf('exact(%s#%s',
             get_class($object->getWrappedObject()),
-            spl_object_hash($object->getWrappedObject())
-        ) . " Object (\n    'objectProphecyClosure' => Closure:%s Object (\n        0 => Closure:%s Object\n    )\n))";
+            spl_object_id($object->getWrappedObject())
+        ) . " Object (\n    'objectProphecyClosure' => Closure#%s Object (\n        0 => Closure#%s Object\n    )\n))";
 
         $this->beConstructedWith($object);
 
-        $hashRegexExpr = '[a-f0-9]{32}';
-        $this->__toString()->shouldMatch(sprintf('/^%s$/', sprintf(preg_quote("$objHash"), $hashRegexExpr, $hashRegexExpr)));
+        $idRegexExpr = '[0-9]+';
+        $this->__toString()->shouldMatch(sprintf('/^%s$/', sprintf(preg_quote("$objHash"), $idRegexExpr, $idRegexExpr)));
     }
 }
 

--- a/spec/Prophecy/Argument/Token/IdenticalValueTokenSpec.php
+++ b/spec/Prophecy/Argument/Token/IdenticalValueTokenSpec.php
@@ -141,14 +141,14 @@ class IdenticalValueTokenSpec extends ObjectBehavior
 
     function it_generates_proper_string_representation_for_object($object)
     {
-        $objHash = sprintf('identical(%s:%s',
+        $objHash = sprintf('identical(%s#%s',
             get_class($object->getWrappedObject()),
-            spl_object_hash($object->getWrappedObject())
-        ) . " Object (\n    'objectProphecyClosure' => Closure:%s Object (\n        0 => Closure:%s Object\n    )\n))";
+            spl_object_id($object->getWrappedObject())
+        ) . " Object (\n    'objectProphecyClosure' => Closure#%s Object (\n        0 => Closure#%s Object\n    )\n))";
 
         $this->beConstructedWith($object);
 
-        $hashRegexExpr = '[a-f0-9]{32}';
-        $this->__toString()->shouldMatch(sprintf('/^%s$/', sprintf(preg_quote("$objHash"), $hashRegexExpr, $hashRegexExpr)));
+        $idRegexExpr = '[0-9]+';
+        $this->__toString()->shouldMatch(sprintf('/^%s$/', sprintf(preg_quote("$objHash"), $idRegexExpr, $idRegexExpr)));
     }
 }

--- a/spec/Prophecy/Util/StringUtilSpec.php
+++ b/spec/Prophecy/Util/StringUtilSpec.php
@@ -71,20 +71,20 @@ class StringUtilSpec extends ObjectBehavior
 
     function it_generates_proper_string_representation_for_object(\stdClass $object)
     {
-        $objHash = sprintf('%s:%s',
+        $objHash = sprintf('%s#%s',
             get_class($object->getWrappedObject()),
-            spl_object_hash($object->getWrappedObject())
-        ) . " Object (\n    'objectProphecyClosure' => Closure:%s Object (\n        0 => Closure:%s Object\n    )\n)";
+            spl_object_id($object->getWrappedObject())
+        ) . " Object (\n    'objectProphecyClosure' => Closure#%s Object (\n        0 => Closure#%s Object\n    )\n)";
 
-        $hashRegexExpr = '[a-f0-9]{32}';
-        $this->stringify($object)->shouldMatch(sprintf('/^%s$/', sprintf(preg_quote("$objHash"), $hashRegexExpr, $hashRegexExpr)));
+        $idRegexExpr = '[0-9]+';
+        $this->stringify($object)->shouldMatch(sprintf('/^%s$/', sprintf(preg_quote("$objHash"), $idRegexExpr, $idRegexExpr)));
     }
 
     function it_generates_proper_string_representation_for_object_without_exporting(\stdClass $object)
     {
-        $objHash = sprintf('%s:%s',
+        $objHash = sprintf('%s#%s',
             get_class($object->getWrappedObject()),
-            spl_object_hash($object->getWrappedObject())
+            spl_object_id($object->getWrappedObject())
         );
 
         $this->stringify($object, false)->shouldReturn("$objHash");

--- a/src/Prophecy/Util/ExportUtil.php
+++ b/src/Prophecy/Util/ExportUtil.php
@@ -91,7 +91,8 @@ class ExportUtil
             }
 
             foreach ($value as $key => $val) {
-                $array[spl_object_hash($val)] = array(
+                // Use the same identifier that would be printed alongside the object's representation elsewhere.
+                $array[spl_object_id($val)] = array(
                     'obj' => $val,
                     'inf' => $value->getInfo(),
                 );
@@ -181,11 +182,11 @@ class ExportUtil
         if (is_object($value)) {
             $class = get_class($value);
 
-            if ($hash = $processed->contains($value)) {
-                return sprintf('%s:%s Object', $class, $hash);
+            if ($processed->contains($value)) {
+                return sprintf('%s#%d Object', $class, spl_object_id($value));
             }
 
-            $hash   = $processed->add($value);
+            $processed->add($value);
             $values = '';
             $array  = self::toArray($value);
 
@@ -202,7 +203,7 @@ class ExportUtil
                 $values = "\n" . $values . $whitespace;
             }
 
-            return sprintf('%s:%s Object (%s)', $class, $hash, $values);
+            return sprintf('%s#%d Object (%s)', $class, spl_object_id($value), $values);
         }
 
         return var_export($value, true);

--- a/src/Prophecy/Util/StringUtil.php
+++ b/src/Prophecy/Util/StringUtil.php
@@ -56,7 +56,7 @@ class StringUtil
             return get_resource_type($value).':'.$value;
         }
         if (is_object($value)) {
-            return $exportObject ? ExportUtil::export($value) : sprintf('%s:%s', get_class($value), spl_object_hash($value));
+            return $exportObject ? ExportUtil::export($value) : sprintf('%s#%s', get_class($value), spl_object_id($value));
         }
         if (true === $value || false === $value) {
             return $value ? 'true' : 'false';


### PR DESCRIPTION
Use a much shorter object id using spl_object_id (available in PHP 7.2+)
This will be shorter and easier to tell apart than hex character hashes
of length 32.

Closes #549

NOTE: I'm not sure if changing the output format would require a major or minor version bump, but that's outside of the scope of this PR

Current:
```
      identical(Double\stdClass\P9:0000000046ef9d1d000000002ac5521e Object (
          'objectProphecyClosure' => Closure:0000000046ef8661000000002ac5521e Object (
              0 => Closure:0000000046ef8661000000002ac5521e Object
          )
      ))
```

Proposed
```
      identical(Double\stdClass\P9#4480 Object (
          'objectProphecyClosure' => Closure#4458 Object (
              0 => Closure#4458 Object
          )
      ))
```