### PR TITLE
Initial compatability support for PHP8.2 for readonly classes.

### DIFF
--- a/fixtures/ReadOnlyClass.php
+++ b/fixtures/ReadOnlyClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Fixtures\Prophecy;
+
+readonly class ReadOnlyClass
+{
+}

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -98,6 +98,12 @@ class ClassMirror
             ), $class);
         }
 
+        if (method_exists(ReflectionClass::class, 'isReadOnly') && true === $class->isReadOnly()) {
+            throw new ClassMirrorException(sprintf(
+                'Could not reflect class %s. Doubling a readonly class is not supported yet.', $class->getName()
+            ), $class);
+        }
+
         $node->setParentClass($class->getName());
 
         foreach ($class->getMethods(ReflectionMethod::IS_ABSTRACT) as $method) {

--- a/tests/Doubler/Generator/ClassMirrorTest.php
+++ b/tests/Doubler/Generator/ClassMirrorTest.php
@@ -645,4 +645,21 @@ class ClassMirrorTest extends TestCase
 
         $classNode = (new ClassMirror())->reflect(new \ReflectionClass('Fixtures\Prophecy\IntersectionArgumentType'), []);
     }
+
+    /**
+     * @test
+     */
+    public function it_throws_an_exception_if_class_is_readonly()
+    {
+        if (PHP_VERSION_ID < 80200) {
+            $this->markTestSkipped('Classes marked readonly are not supported in this PHP version.');
+        }
+
+        $this->expectException(ClassMirrorException::class);
+        $this->expectExceptionMessageMatches(
+            '/Could not reflect class [^\.]*.\. Doubling a readonly class is not supported yet./'
+        );
+
+        $classNode = (new ClassMirror())->reflect(new \ReflectionClass('Fixtures\Prophecy\ReadOnlyClass'), []);
+    }
 }


### PR DESCRIPTION
readonly classes will throw a ClassMirrorException until supported.