### PR TITLE
Add the ability to customize the __toString representation of a CallbackToken

### DIFF
--- a/spec/Prophecy/Argument/Token/CallbackTokenSpec.php
+++ b/spec/Prophecy/Argument/Token/CallbackTokenSpec.php
@@ -39,4 +39,11 @@ class CallbackTokenSpec extends ObjectBehavior
     {
         $this->__toString()->shouldReturn('callback()');
     }
+
+    function its_string_representation_can_be_customized()
+    {
+        $this->beConstructedWith('get_class', 'MyCustomTestCase');
+
+        $this->__toString()->shouldReturn('MyCustomTestCase');
+    }
 }

--- a/spec/Prophecy/ArgumentSpec.php
+++ b/spec/Prophecy/ArgumentSpec.php
@@ -37,6 +37,13 @@ class ArgumentSpec extends ObjectBehavior
         $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\CallbackToken');
     }
 
+    function it_supports_customizing_tostring_representation_for_callback_token()
+    {
+        $token = $this->that('get_class', 'MyCustomTestCase');
+        $token->shouldBeAnInstanceOf('Prophecy\Argument\Token\CallbackToken');
+        $token->__toString()->shouldReturn('MyCustomTestCase');
+    }
+
     function it_has_a_shortcut_for_object_state_token()
     {
         $token = $this->which('getName', 'everzet');

--- a/src/Prophecy/Argument.php
+++ b/src/Prophecy/Argument.php
@@ -61,12 +61,13 @@ class Argument
      * Checks that argument matches provided callback.
      *
      * @param callable $callback
+     * @param string|null $customStringRepresentation Customize the __toString() representation of this token
      *
      * @return Token\CallbackToken
      */
-    public static function that($callback)
+    public static function that($callback, ?string $customStringRepresentation = null)
     {
-        return new Token\CallbackToken($callback);
+        return new Token\CallbackToken($callback, $customStringRepresentation);
     }
 
     /**

--- a/src/Prophecy/Argument/Token/CallbackToken.php
+++ b/src/Prophecy/Argument/Token/CallbackToken.php
@@ -23,13 +23,19 @@ class CallbackToken implements TokenInterface
     private $callback;
 
     /**
+     * @var string|null
+     */
+    private $customStringRepresentation;
+
+    /**
      * Initializes token.
      *
      * @param callable $callback
+     * @param string|null $customStringRepresentation Customize the __toString() representation of this token
      *
      * @throws \Prophecy\Exception\InvalidArgumentException
      */
-    public function __construct($callback)
+    public function __construct($callback, ?string $customStringRepresentation = null)
     {
         if (!is_callable($callback)) {
             throw new InvalidArgumentException(sprintf(
@@ -39,6 +45,7 @@ class CallbackToken implements TokenInterface
         }
 
         $this->callback = $callback;
+        $this->customStringRepresentation = $customStringRepresentation;
     }
 
     /**
@@ -70,6 +77,10 @@ class CallbackToken implements TokenInterface
      */
     public function __toString()
     {
+        if ($this->customStringRepresentation !== null) {
+            return $this->customStringRepresentation;
+        }
+
         return 'callback()';
     }
 }


### PR DESCRIPTION
Whenever we run tests using CallbackToken's and the CallbackToken fails to match, we get unhelpful assertion failures. When the specific test case does not use a lot of CallbackToken's, it is pretty easy to track which assertion has failed. This is aimed at the scenario where there are multiple identical function signatures with different CallbackToken's, so the following example becomes more readable:

```
    [exec]  Test  tests/unit/Example/ExampleTest.php:testItDoesSomething
     [exec] Expected exactly 1 calls that match:
     [exec]   Double\ExampleInterface\P2->doSomething(callback())
     [exec] but none were made.
     [exec] Recorded `doSomething(...)` calls:
```
should become
```
    [exec]  Test  tests/unit/Example/ExampleTest.php:testItDoesSomething
     [exec] Expected exactly 1 calls that match:
     [exec]   Double\ExampleInterface\P2->doSomething(Clear description)
     [exec] but none were made.
     [exec] Recorded `doSomething(...)` calls:
```

If you would like a separate issue for discussion, please let me know so I can create one.