### PR TITLE
Remove unused argument in the comparators

### DIFF
--- a/src/Prophecy/Comparator/ClosureComparator.php
+++ b/src/Prophecy/Comparator/ClosureComparator.php
@@ -27,7 +27,7 @@ final class ClosureComparator extends Comparator
             && is_object($actual) && $actual instanceof \Closure;
     }
 
-    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false, array &$processed = array()): void
+    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false): void
     {
         if ($expected !== $actual) {
             throw new ComparisonFailure(


### PR DESCRIPTION
This extra argument does not exist in the base Comparator class, only in ObjectComparator.