### PR TITLE
Allow to work with PHPUnit 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php":                               "^7.2 || 8.0.* || 8.1.* || 8.2.*",
         "phpdocumentor/reflection-docblock": "^5.2",
-        "sebastian/comparator":              "^3.0 || ^4.0",
+        "sebastian/comparator":              "^3.0 || ^4.0 || ^5.0",
         "doctrine/instantiator":             "^1.2 || ^2.0",
         "sebastian/recursion-context":       "^3.0 || ^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "phpspec/phpspec": "^6.0 || ^7.0",
         "phpstan/phpstan": "^1.9",
-        "phpunit/phpunit": "^8.0 || ^9.0"
+        "phpunit/phpunit": "^8.0 || ^9.0 || ^10.0"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpdocumentor/reflection-docblock": "^5.2",
         "sebastian/comparator":              "^3.0 || ^4.0 || ^5.0",
         "doctrine/instantiator":             "^1.2 || ^2.0",
-        "sebastian/recursion-context":       "^3.0 || ^4.0"
+        "sebastian/recursion-context":       "^3.0 || ^4.0 || ^5.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
This draft of a PR was needed for me to work on PHPUnit 10 compat on another project, see https://github.com/facile-it/paraunit/pull/172

It allows two packages to the next major version (5), with no other code modifications since there are no BC impacting Prophecy.