### PR TITLE
Add support for doctrine/instantiator 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php":                               "^7.2 || 8.0.* || 8.1.* || 8.2.*",
         "phpdocumentor/reflection-docblock": "^5.2",
         "sebastian/comparator":              "^3.0 || ^4.0",
-        "doctrine/instantiator":             "^1.2",
+        "doctrine/instantiator":             "^1.2 || ^2.0",
         "sebastian/recursion-context":       "^3.0 || ^4.0"
     },
 


### PR DESCRIPTION
We are not affected by the BC break in it (which is most that some constants that were deprecated for public access are not actually private constants).

This keeps support for doctrine/instantiator 1.x because 2.0 requires PHP 8.1+ (and it makes it easier for projects to avoid dependency conflicts).