### PR TITLE
Refactor code to avoid extending the sebastian/comparator factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
 
     "autoload-dev": {
         "psr-4": {
-            "Fixtures\\Prophecy\\": "fixtures"
+            "Fixtures\\Prophecy\\": "fixtures",
+            "Tests\\Prophecy\\": "tests"
         }
     },
 

--- a/src/Prophecy/Argument/Token/ExactValueToken.php
+++ b/src/Prophecy/Argument/Token/ExactValueToken.php
@@ -11,8 +11,9 @@
 
 namespace Prophecy\Argument\Token;
 
+use Prophecy\Comparator\FactoryProvider;
 use SebastianBergmann\Comparator\ComparisonFailure;
-use Prophecy\Comparator\Factory as ComparatorFactory;
+use SebastianBergmann\Comparator\Factory as ComparatorFactory;
 use Prophecy\Util\StringUtil;
 
 /**
@@ -40,7 +41,7 @@ class ExactValueToken implements TokenInterface
         $this->value = $value;
         $this->util  = $util ?: new StringUtil();
 
-        $this->comparatorFactory = $comparatorFactory ?: ComparatorFactory::getInstance();
+        $this->comparatorFactory = $comparatorFactory ?: FactoryProvider::getInstance();
     }
 
     /**

--- a/src/Prophecy/Argument/Token/ObjectStateToken.php
+++ b/src/Prophecy/Argument/Token/ObjectStateToken.php
@@ -11,8 +11,9 @@
 
 namespace Prophecy\Argument\Token;
 
+use Prophecy\Comparator\FactoryProvider;
 use SebastianBergmann\Comparator\ComparisonFailure;
-use Prophecy\Comparator\Factory as ComparatorFactory;
+use SebastianBergmann\Comparator\Factory as ComparatorFactory;
 use Prophecy\Util\StringUtil;
 
 /**
@@ -30,10 +31,8 @@ class ObjectStateToken implements TokenInterface
     /**
      * Initializes token.
      *
-     * @param string            $methodName
-     * @param mixed             $value             Expected return value
-     * @param null|StringUtil   $util
-     * @param ComparatorFactory $comparatorFactory
+     * @param string $methodName
+     * @param mixed  $value             Expected return value
      */
     public function __construct(
         $methodName,
@@ -45,7 +44,7 @@ class ObjectStateToken implements TokenInterface
         $this->value = $value;
         $this->util  = $util ?: new StringUtil;
 
-        $this->comparatorFactory = $comparatorFactory ?: ComparatorFactory::getInstance();
+        $this->comparatorFactory = $comparatorFactory ?: FactoryProvider::getInstance();
     }
 
     /**

--- a/src/Prophecy/Comparator/FactoryProvider.php
+++ b/src/Prophecy/Comparator/FactoryProvider.php
@@ -11,37 +11,30 @@
 
 namespace Prophecy\Comparator;
 
-use SebastianBergmann\Comparator\Factory as BaseFactory;
+use SebastianBergmann\Comparator\Factory;
 
 /**
  * Prophecy comparator factory.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @deprecated Use "Prophecy\Comparator\FactoryProvider" instead to get a "SebastianBergmann\Comparator\Factory" instance.
  */
-final class Factory extends BaseFactory
+final class FactoryProvider
 {
     /**
-     * @var Factory
+     * @var Factory|null
      */
     private static $instance;
 
-    public function __construct()
+    private function __construct()
     {
-        parent::__construct();
-
-        $this->register(new ClosureComparator());
-        $this->register(new ProphecyComparator());
     }
 
-    /**
-     * @return Factory
-     */
-    public static function getInstance()
+    public static function getInstance(): Factory
     {
         if (self::$instance === null) {
-            self::$instance = new Factory;
+            self::$instance = new Factory();
+            self::$instance->register(new ClosureComparator());
+            self::$instance->register(new ProphecyComparator());
         }
 
         return self::$instance;

--- a/src/Prophecy/Prophecy/ObjectProphecy.php
+++ b/src/Prophecy/Prophecy/ObjectProphecy.php
@@ -11,8 +11,9 @@
 
 namespace Prophecy\Prophecy;
 
+use Prophecy\Comparator\FactoryProvider;
 use SebastianBergmann\Comparator\ComparisonFailure;
-use Prophecy\Comparator\Factory as ComparatorFactory;
+use SebastianBergmann\Comparator\Factory as ComparatorFactory;
 use Prophecy\Call\Call;
 use Prophecy\Doubler\LazyDouble;
 use Prophecy\Argument\ArgumentsWildcard;
@@ -50,7 +51,7 @@ class ObjectProphecy implements ProphecyInterface
         $this->callCenter = $callCenter ?: new CallCenter;
         $this->revealer   = $revealer ?: new Revealer;
 
-        $this->comparatorFactory = $comparatorFactory ?: ComparatorFactory::getInstance();
+        $this->comparatorFactory = $comparatorFactory ?: FactoryProvider::getInstance();
     }
 
     /**

--- a/tests/Comparator/FactoryProviderTest.php
+++ b/tests/Comparator/FactoryProviderTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Prophecy\Comparator;
+
+use Prophecy\Comparator\ClosureComparator;
+use Prophecy\Comparator\FactoryProvider;
+use PHPUnit\Framework\TestCase;
+
+class FactoryProviderTest extends TestCase
+{
+    /**
+     * @test
+     */
+    function it_should_have_ClosureComparator_registered()
+    {
+        $comparator = FactoryProvider::getInstance()->getComparatorFor(function(){}, function(){});
+
+        $this->assertInstanceOf(ClosureComparator::class, $comparator);
+    }
+}


### PR DESCRIPTION
Version 5 of the library makes the Factory class final.

Unfortunately, the existing `Prophecy\Comparator\Factory` is part of the public API of other classes currently, so we cannot consider that it is an internal class that we are free to remove.