### PR TITLE
allow recursion-context and comparator v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php":                               "^7.2 || 8.0.* || 8.1.* || 8.2.*",
         "phpdocumentor/reflection-docblock": "^5.2",
-        "sebastian/comparator":              "^3.0 || ^4.0",
+        "sebastian/comparator":              "^3.0 || ^4.0 || ^5.0",
         "doctrine/instantiator":             "^1.2 || ^2.0",
         "sebastian/recursion-context":       "^3.0 || ^4.0 || ^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpdocumentor/reflection-docblock": "^5.2",
         "sebastian/comparator":              "^3.0 || ^4.0",
         "doctrine/instantiator":             "^1.2 || ^2.0",
-        "sebastian/recursion-context":       "^3.0 || ^4.0"
+        "sebastian/recursion-context":       "^3.0 || ^4.0 || ^5.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
PhpUnit 10 requires `sebastian/recursion-context` and `sebastian/comparator` v5. Allow these versions so that prophecy can be installed alongside PhpUnit 10 (eg for `prophecy-phpunit`).

Closes #590 