### PR TITLE
feat: add control over class/interface existence before trying to prophesize it

### DIFF
--- a/spec/Prophecy/ProphetSpec.php
+++ b/spec/Prophecy/ProphetSpec.php
@@ -78,4 +78,13 @@ class ProphetSpec extends ObjectBehavior
     {
         $this->getDoubler()->shouldReturn($doubler);
     }
+
+    function it_throws_ClassNotFound_if_class_to_double_does_not_exist()
+    {
+        $this->shouldThrow('Prophecy\Exception\Doubler\ClassNotFoundException')
+            ->duringProphesize('This\ClassOrInterface\Does\Not\Exist');
+
+        $this->shouldNotThrow()
+            ->duringProphesize();
+    }
 }

--- a/spec/Prophecy/ProphetSpec.php
+++ b/spec/Prophecy/ProphetSpec.php
@@ -79,11 +79,15 @@ class ProphetSpec extends ObjectBehavior
         $this->getDoubler()->shouldReturn($doubler);
     }
 
-    function it_throws_ClassNotFound_if_class_to_double_does_not_exist()
+    function it_throws_ClassNotFound_if_class_to_prophesize_does_not_exist()
     {
         $this->shouldThrow('Prophecy\Exception\Doubler\ClassNotFoundException')
             ->duringProphesize('This\ClassOrInterface\Does\Not\Exist');
 
+    }
+
+    function it_does_not_throw_when_creating_void_mock()
+    {
         $this->shouldNotThrow()
             ->duringProphesize();
     }

--- a/src/Prophecy/Prophet.php
+++ b/src/Prophecy/Prophet.php
@@ -15,6 +15,7 @@ use Prophecy\Doubler\CachedDoubler;
 use Prophecy\Doubler\Doubler;
 use Prophecy\Doubler\LazyDouble;
 use Prophecy\Doubler\ClassPatch;
+use Prophecy\Exception\Doubler\ClassNotFoundException;
 use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\Prophecy\RevealerInterface;
 use Prophecy\Prophecy\Revealer;
@@ -83,12 +84,19 @@ class Prophet
             $this->revealer
         );
 
-        if ($classOrInterface && class_exists($classOrInterface)) {
-            return $prophecy->willExtend($classOrInterface);
-        }
+        if ($classOrInterface) {
+            if (class_exists($classOrInterface)) {
+                return $prophecy->willExtend($classOrInterface);
+            }
 
-        if ($classOrInterface && interface_exists($classOrInterface)) {
-            return $prophecy->willImplement($classOrInterface);
+            if (interface_exists($classOrInterface)) {
+                return $prophecy->willImplement($classOrInterface);
+            }
+
+            throw new ClassNotFoundException(sprintf(
+                'Cannot prophesize class %s, because it cannot be found.',
+                $classOrInterface
+            ), $classOrInterface);
         }
 
         return $prophecy;


### PR DESCRIPTION
Currently, if we try to prophesize a class or an interface that doesn't exist, the mock is created anyway, but with nothing inside. This behavior is disturbing, because then, when we try to set a method behavior inside, we get a "method not found" error, as said in https://github.com/phpspec/prophecy/issues/154#issuecomment-184572986:

```php
// The Person class does not exist
$mock = $this->prophesize(Person::class);
$mock->getName()->willReturn('Jérôme');
// Prophecy\Exception\Doubler\MethodNotFoundException: Method `Double\stdClass\P1::getName()` is not defined.
```

With this PR, trying to prophesize a class that does not exist will now throw a `ClassNotFoundException` with a comprehensive message that should help understanding what's actually happening.
This new behavior doesn't impact the creation of empty prophecy (i.e. calling `prophesize` without any argument). However, this might still be a BC break for people who use this method to mock inexistant classes on purpose.