### PR TITLE
Do not allow null shorthand with standalone null type

### DIFF
--- a/fixtures/TentativeReturnTypeNull.php
+++ b/fixtures/TentativeReturnTypeNull.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Fixtures\Prophecy;
+
+class TentativeReturnTypeNull
+{
+    #[\ReturnTypeWillChange()]
+    public function method(): ?string
+    {
+        return null;
+    }
+}

--- a/src/Prophecy/Doubler/Generator/Node/TypeNodeAbstract.php
+++ b/src/Prophecy/Doubler/Generator/Node/TypeNodeAbstract.php
@@ -21,7 +21,7 @@ abstract class TypeNodeAbstract
 
     public function canUseNullShorthand(): bool
     {
-        return isset($this->types['null']) && count($this->types) <= 2;
+        return isset($this->types['null']) && count($this->types) === 2;
     }
 
     /**

--- a/tests/Doubler/Generator/Node/TypeNodeAbstractTest.php
+++ b/tests/Doubler/Generator/Node/TypeNodeAbstractTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Prophecy\Doubler\Generator\Node;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Doubler\Generator\Node\ArgumentTypeNode;
+use Prophecy\Doubler\Generator\Node\ReturnTypeNode;
+use Prophecy\Doubler\Generator\Node\TypeNodeAbstract;
+
+class TypeNodeAbstractTest extends TestCase
+{
+    /**
+     * @return \Generator<array{0: TypeNodeAbstract, 1?: bool}>
+     */
+    public static function childClassDataProvider(): \Generator
+    {
+        $typesCombination = [
+            ['bool', 'null'],
+            ['int', 'bool', 'null'],
+        ];
+
+        if (PHP_VERSION_ID >= 80200) {
+            $typesCombination[] = ['null'];
+        }
+
+        foreach ($typesCombination as $types) {
+            $count = count($types);
+            $expected = $count === 2;
+
+            yield $count . ' return types' => [new ReturnTypeNode(...$types), $expected];
+            yield $count . ' argument types' => [new ArgumentTypeNode(...$types), $expected];
+        }
+    }
+
+    /**
+     * @test
+     * @dataProvider childClassDataProvider
+     */
+    public function it_can_use_null_shorthand_only_with_two_types(TypeNodeAbstract $node, bool $expected): void
+    {
+        $this->assertSame($expected, $node->canUseNullShorthand());
+    }
+}


### PR DESCRIPTION
I got an issue with `\SplFileObject::getChildren`, which in PHP 8.2 has a tentative return type of `null`. The code generator was creating a return type written as `): ? {`, creating a syntax error on the double. This fixes it. 