### PR TITLE
Fix the testsuite

### DIFF
--- a/spec/Prophecy/Comparator/FactorySpec.php
+++ b/spec/Prophecy/Comparator/FactorySpec.php
@@ -2,11 +2,23 @@
 
 namespace spec\Prophecy\Comparator;
 
+use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Prophecy\Comparator\Factory;
+use SebastianBergmann\Comparator\Factory as BaseFactory;
 
 class FactorySpec extends ObjectBehavior
 {
+    function let()
+    {
+        $ref = new \ReflectionClass(BaseFactory::class);
+
+        if ($ref->isFinal()) {
+            throw new SkippingException(sprintf('The deprecated "%s" class cannot be used with sebastian/comparator 5+.', Factory::class));
+        }
+    }
+
     function it_extends_Sebastian_Comparator_Factory()
     {
         $this->shouldHaveType('SebastianBergmann\Comparator\Factory');

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Prophecy;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophet;
+
+class FunctionalTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function case_insensitive_method_names()
+    {
+        $prophet = new Prophet();
+        $prophecy = $prophet->prophesize('ArrayObject');
+        $prophecy->offsetGet(1)->willReturn(1)->shouldBeCalledTimes(1);
+        $prophecy->offsetget(2)->willReturn(2)->shouldBeCalledTimes(1);
+        $prophecy->OffsetGet(3)->willReturn(3)->shouldBeCalledTimes(1);
+
+        $arrayObject = $prophecy->reveal();
+        self::assertSame(1, $arrayObject->offsetGet(1));
+        self::assertSame(2, $arrayObject->offsetGet(2));
+        self::assertSame(3, $arrayObject->offsetGet(3));
+    }
+}


### PR DESCRIPTION
As PHPUnit 10+ does not include a builtin Prophecy integration, we should not rely on it to write tests.

Thus, when writing tests for Prophecy itself, it is better if the test shows usages of the Prophecy API instead of hiding it in the PHPunit integration (which would also run additional code to verify predictions, which might make the test confusing).