### PR TITLE
Fix phpstan errors

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Parameter \\#1 \\$value of function strval expects bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 2
+			path: src/Prophecy/Argument/Token/ExactValueToken.php
+
+		-
 			message: "#^Method Prophecy\\\\Call\\\\CallCenter\\:\\:indentArguments\\(\\) should return array\\<string\\> but returns array\\<string\\>\\|null\\.$#"
 			count: 1
 			path: src/Prophecy/Call/CallCenter.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,5 +4,7 @@ parameters:
     treatPhpDocTypesAsCertain: false
     paths:
         - ./src/
+    excludePaths:
+        - src/Prophecy/Comparator/Factory.php
 includes:
     - phpstan-baseline.neon

--- a/src/Prophecy/Comparator/ClosureComparator.php
+++ b/src/Prophecy/Comparator/ClosureComparator.php
@@ -21,22 +21,38 @@ use SebastianBergmann\Comparator\ComparisonFailure;
  */
 final class ClosureComparator extends Comparator
 {
+    /**
+     * @param mixed $expected
+     * @param mixed $actual
+     */
     public function accepts($expected, $actual): bool
     {
         return is_object($expected) && $expected instanceof \Closure
             && is_object($actual) && $actual instanceof \Closure;
     }
 
+    /**
+     * @param mixed $expected
+     * @param mixed $actual
+     * @param float $delta
+     * @param bool  $canonicalize
+     * @param bool  $ignoreCase
+     */
     public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false): void
     {
         if ($expected !== $actual) {
+            // Support for sebastian/comparator < 5
+            if ((new \ReflectionMethod(ComparisonFailure::class, '__construct'))->getNumberOfParameters() >= 6) {
+                // @phpstan-ignore-next-line
+                throw new ComparisonFailure($expected, $actual, '', '', false, 'all closures are different if not identical');
+            }
+
             throw new ComparisonFailure(
                 $expected,
                 $actual,
                 // we don't need a diff
                 '',
                 '',
-                false,
                 'all closures are different if not identical'
             );
         }

--- a/src/Prophecy/Comparator/ProphecyComparator.php
+++ b/src/Prophecy/Comparator/ProphecyComparator.php
@@ -19,12 +19,23 @@ use SebastianBergmann\Comparator\ObjectComparator;
  */
 class ProphecyComparator extends ObjectComparator
 {
+    /**
+     * @param mixed $expected
+     * @param mixed $actual
+     */
     public function accepts($expected, $actual): bool
     {
         return is_object($expected) && is_object($actual) && $actual instanceof ProphecyInterface;
     }
 
     /**
+     * @param mixed $expected
+     * @param mixed $actual
+     * @param float $delta
+     * @param bool  $canonicalize
+     * @param bool  $ignoreCase
+     * @param array $processed
+     *
      * @phpstan-param list<array{object, object}> $processed
      */
     public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false, array &$processed = array()): void

--- a/src/Prophecy/Util/ExportUtil.php
+++ b/src/Prophecy/Util/ExportUtil.php
@@ -147,6 +147,7 @@ class ExportUtil
                 return 'Array &' . $key;
             }
 
+            \assert(\is_array($value));
             $array  = $value;
             $key    = $processed->add($value);
             $values = '';
@@ -171,10 +172,12 @@ class ExportUtil
             $class = get_class($value);
 
             if ($processed->contains($value)) {
+                \assert(\is_object($value));
                 return sprintf('%s#%d Object', $class, spl_object_id($value));
             }
 
             $processed->add($value);
+            \assert(\is_object($value));
             $values = '';
             $array  = self::toArray($value);
 


### PR DESCRIPTION
when using sebastian/comparator 5.x in CI, phpstan was complaining about missing types (as the parent removed the phpdoc in favor of native types). I'm using phpdoc here as adding argument types would require dropping support for older versions (and so for PHP <8.1)