### PR TITLE
Implement the DoubleInterface on double classes

### DIFF
--- a/src/Prophecy/Doubler/Doubler.php
+++ b/src/Prophecy/Doubler/Doubler.php
@@ -133,6 +133,7 @@ class Doubler
                 $patch->apply($node);
             }
         }
+        $node->addInterface(DoubleInterface::class);
 
         $this->creator->create($name, $node);
 

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Prophecy;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Doubler\DoubleInterface;
+use Prophecy\Prophecy\ProphecySubjectInterface;
 use Prophecy\Prophet;
 
 class FunctionalTest extends TestCase
@@ -22,5 +24,27 @@ class FunctionalTest extends TestCase
         self::assertSame(1, $arrayObject->offsetGet(1));
         self::assertSame(2, $arrayObject->offsetGet(2));
         self::assertSame(3, $arrayObject->offsetGet(3));
+    }
+
+    /**
+     * @test
+     */
+    public function it_implements_the_double_interface()
+    {
+        $prophet = new Prophet();
+        $object = $prophet->prophesize('stdClass')->reveal();
+
+        $this->assertInstanceOf(DoubleInterface::class, $object);
+    }
+
+    /**
+     * @test
+     */
+    public function it_implements_the_prophecy_subject_interface()
+    {
+        $prophet = new Prophet();
+        $object = $prophet->prophesize('stdClass')->reveal();
+
+        $this->assertInstanceOf(ProphecySubjectInterface::class, $object);
     }
 }


### PR DESCRIPTION
While working on improving the code analysis, I discovered that the DoubleInterface is not implemented in double classes, contrary to what is documented in the signature of the Doubler.

I also added a test covering the fact that we implement ProphecySubjectInterface, but this one was already passing.