### PR TITLE
Add 'dev' keyword to composer.json to trigger `--dev` prompt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name":         "phpspec/prophecy",
     "description":  "Highly opinionated mocking framework for PHP 5.3+",
-    "keywords":     ["Mock", "Stub", "Dummy", "Double", "Fake", "Spy"],
+    "keywords":     ["Mock", "Stub", "Dummy", "Double", "Fake", "Spy", "dev"],
     "homepage":     "https://github.com/phpspec/prophecy",
     "type":         "library",
     "license":      "MIT",


### PR DESCRIPTION
Composer 2.4 and later can automatically suggest to use the `--dev` flag when someone runs `composer require phpspec/prophecy` without the `--dev` flag.

See [Get Composer to suggest dev packages to `require-dev`](https://php.watch/articles/composer-prompt-require-dev-dev-packages)