### PR TITLE
Fixed deprecation warning in DisableConstructorPatch.php

### DIFF
--- a/src/Prophecy/Doubler/ClassPatch/DisableConstructorPatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/DisableConstructorPatch.php
@@ -59,7 +59,7 @@ class DisableConstructorPatch implements ClassPatchInterface
 
         $constructor->setCode(<<<PHP
 if (0 < func_num_args()) {
-    call_user_func_array(array('parent', '__construct'), func_get_args());
+    call_user_func_array(array(parent::class, '__construct'), func_get_args());
 }
 PHP
         );


### PR DESCRIPTION
Fixes the "Use of "parent" in callables is deprecated" deprecation error when a constructor with arguments is used. See [PHP RFC: Deprecate partially supported callables](https://wiki.php.net/rfc/deprecate_partially_supported_callables).

I ran into this today and fixed it according to to the proposed replacement stated in the PHP RFC.