### PR TITLE
Allow sebastian/comparator 6 (to allow PHPUnit 11)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php":                               "^7.2 || 8.0.* || 8.1.* || 8.2.* || 8.3.*",
         "phpdocumentor/reflection-docblock": "^5.2",
-        "sebastian/comparator":              "^3.0 || ^4.0 || ^5.0",
+        "sebastian/comparator":              "^3.0 || ^4.0 || ^5.0 || ^6.0",
         "doctrine/instantiator":             "^1.2 || ^2.0",
         "sebastian/recursion-context":       "^3.0 || ^4.0 || ^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpdocumentor/reflection-docblock": "^5.2",
         "sebastian/comparator":              "^3.0 || ^4.0 || ^5.0 || ^6.0",
         "doctrine/instantiator":             "^1.2 || ^2.0",
-        "sebastian/recursion-context":       "^3.0 || ^4.0 || ^5.0"
+        "sebastian/recursion-context":       "^3.0 || ^4.0 || ^5.0 || ^6.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
This is a blocker for end users to upgrade to PHPUnit 11.

This new major of `sebastian/comparator` does not have any meaningful change, as you can see:
* from the changelog: https://github.com/sebastianbergmann/comparator/blob/main/ChangeLog.md#600---2024-02-02
* or the full diff (only CS fixes): https://github.com/sebastianbergmann/comparator/compare/5.0.1...6.0.0

[EDIT] Same goes for `sebastian/recursion-context`:
 * changelog: https://github.com/sebastianbergmann/recursion-context/blob/main/ChangeLog.md#600---2024-02-02
 * full diff: https://github.com/sebastianbergmann/recursion-context/compare/5.0.0...6.0.0