### PR TITLE
Fix generation of enum default values with PHP 8.1

### DIFF
--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -110,7 +110,13 @@ class ClassCodeGenerator
             $php .= '$'.$argument->getName();
 
             if ($argument->isOptional() && !$argument->isVariadic()) {
-                $php .= ' = '.var_export($argument->getDefault(), true);
+                $default = var_export($argument->getDefault(), true);
+
+                if ($argument->getDefault() instanceof \UnitEnum && 0 !== strpos($default, '\\'))  {
+                    $default = '\\'.$default;
+                }
+
+                $php .= ' = '.$default;
             }
 
             return $php;

--- a/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
+++ b/src/Prophecy/Doubler/Generator/ClassCodeGenerator.php
@@ -112,6 +112,7 @@ class ClassCodeGenerator
             if ($argument->isOptional() && !$argument->isVariadic()) {
                 $default = var_export($argument->getDefault(), true);
 
+                // This is necessary for PHP 8.1, as enum cases are exported without a leading slash in this version
                 if ($argument->getDefault() instanceof \UnitEnum && 0 !== strpos($default, '\\'))  {
                     $default = '\\'.$default;
                 }


### PR DESCRIPTION
Fixes #567

The problem is, that the generated default value is in the wrong namespace, because the leading `\` is missing. 

This seems only to be a problem in PHP 8.1, see: https://3v4l.org/3JPCM