### PR TITLE
Update the checkout action to avoid a deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
             composer-flags: "--ignore-platform-req=php+" # TODO move that to a normal job without flag once phpspec supports it
 
     steps:
-      -   uses: actions/checkout@v3
+      -   uses: actions/checkout@v4
 
       -   name: Set up PHP
           uses: shivammathur/setup-php@v2
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Static analysis
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.