### PR TITLE
Simplify CI script for PHP 8.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]
+        php: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]
         composer-flags: [ "" ]
         include:
           - php: 7.2
             composer-flags: "--prefer-lowest"
-          - php: '8.3'
-            composer-flags: "--ignore-platform-req=php+" # TODO move that to a normal job without flag once phpspec supports it
 
     steps:
       -   uses: actions/checkout@v4


### PR DESCRIPTION
Remote the not longer needed ignore platfrom reqs as phpspec now supports PHP 8.3.