### PR TITLE
 Allow sebastian/* 6 (to allow PHPUnit 12)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     "require": {
         "php":                               "^7.2 || 8.0.* || 8.1.* || 8.2.* || 8.3.* || 8.4.*",
         "phpdocumentor/reflection-docblock": "^5.2",
-        "sebastian/comparator":              "^3.0 || ^4.0 || ^5.0 || ^6.0",
+        "sebastian/comparator":              "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
         "doctrine/instantiator":             "^1.2 || ^2.0",
-        "sebastian/recursion-context":       "^3.0 || ^4.0 || ^5.0 || ^6.0"
+        "sebastian/recursion-context":       "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
This is the same as #616, but for PHPUnit 12:
 * allows `sebastian/comparator` 7
 * allows `sebastian/recursion-context` 7

Both packages do not have any meaningful breaking changes, they only bump the requirement for PHP:
 * changelogs:
   * https://github.com/sebastianbergmann/comparator/blob/main/ChangeLog.md#700---2025-02-07
   * https://github.com/sebastianbergmann/recursion-context/blob/main/ChangeLog.md#700---2025-02-07
 * diffs (only CS/config/CI changes)
   * https://github.com/sebastianbergmann/comparator/compare/6.3...7.0.0
   * https://github.com/sebastianbergmann/recursion-context/compare/6.0...7.0.0
