### PR TITLE
Upgrade PHP minimum version to 8.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["7.4", "8.0", "8.1", "8.2", "8.3"]
+        php: ["8.2", "8.3"]
         composer-flags: [ "" ]
         experimental: [ false ]
         include:
-          - php: 7.4
+          - php: 8.2
             composer-flags: "--prefer-lowest"
           - php: "8.4" # TODO move that to a normal job once phpspec supports PHP 8.4
             composer-flags: "--ignore-platform-req=php+"
@@ -59,7 +59,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.2"
+          php-version: "8.3"
           coverage: none
       - name: Install dependencies
         run: COMPOSER_ROOT_VERSION=dev-master composer update --no-scripts
@@ -73,7 +73,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.2"
+          php-version: "8.3"
           coverage: none
       - name: Install dependencies
         run: COMPOSER_ROOT_VERSION=dev-master composer update --no-scripts

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /phpstan.neon
 /phpunit.xml
 /.phpunit.result.cache
+/.phpunit.cache/

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "friendsofphp/php-cs-fixer": "^3.40",
         "phpspec/phpspec": "^6.0 || ^7.0",
         "phpstan/phpstan": "^2.1.13",
-        "phpunit/phpunit": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0"
+        "phpunit/phpunit": "^11.0 || ^12.0"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
 
     "require": {
-        "php":                               "^7.4 || 8.0.* || 8.1.* || 8.2.* || 8.3.* || 8.4.*",
+        "php":                               "8.2.* || 8.3.* || 8.4.*",
         "phpdocumentor/reflection-docblock": "^5.2",
         "sebastian/comparator":              "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
         "doctrine/instantiator":             "^1.2 || ^2.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,24 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <php>
-        <ini name="error_reporting" value="-1" />
-    </php>
-
-    <testsuites>
-        <testsuite name="PhpSpec Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.1/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php" cacheDirectory=".phpunit.cache">
+  <php>
+    <ini name="error_reporting" value="-1"/>
+  </php>
+  <testsuites>
+    <testsuite name="PhpSpec Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory>./src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Prophecy/Doubler/ClassPatch/TraversablePatch.php
+++ b/src/Prophecy/Doubler/ClassPatch/TraversablePatch.php
@@ -66,23 +66,23 @@ class TraversablePatch implements ClassPatchInterface
         $node->addInterface('Iterator');
 
         $currentMethod = new MethodNode('current');
-        (\PHP_VERSION_ID >= 80100) && $currentMethod->setReturnTypeNode(new ReturnTypeNode('mixed'));
+        $currentMethod->setReturnTypeNode(new ReturnTypeNode('mixed'));
         $node->addMethod($currentMethod);
 
         $keyMethod = new MethodNode('key');
-        (\PHP_VERSION_ID >= 80100) && $keyMethod->setReturnTypeNode(new ReturnTypeNode('mixed'));
+        $keyMethod->setReturnTypeNode(new ReturnTypeNode('mixed'));
         $node->addMethod($keyMethod);
 
         $nextMethod = new MethodNode('next');
-        (\PHP_VERSION_ID >= 80100) && $nextMethod->setReturnTypeNode(new ReturnTypeNode('void'));
+        $nextMethod->setReturnTypeNode(new ReturnTypeNode('void'));
         $node->addMethod($nextMethod);
 
         $rewindMethod = new MethodNode('rewind');
-        (\PHP_VERSION_ID >= 80100) && $rewindMethod->setReturnTypeNode(new ReturnTypeNode('void'));
+        $rewindMethod->setReturnTypeNode(new ReturnTypeNode('void'));
         $node->addMethod($rewindMethod);
 
         $validMethod = new MethodNode('valid');
-        (\PHP_VERSION_ID >= 80100) && $validMethod->setReturnTypeNode(new ReturnTypeNode('bool'));
+        $validMethod->setReturnTypeNode(new ReturnTypeNode('bool'));
         $node->addMethod($validMethod);
     }
 

--- a/src/Prophecy/Doubler/Generator/ClassMirror.php
+++ b/src/Prophecy/Doubler/Generator/ClassMirror.php
@@ -217,7 +217,7 @@ class ClassMirror
             return true;
         }
 
-        return $parameter->isOptional() || ($parameter->allowsNull() && $parameter->getType() && \PHP_VERSION_ID < 80100);
+        return $parameter->isOptional();
     }
 
     /**
@@ -246,11 +246,9 @@ class ClassMirror
 
         } elseif ($type instanceof ReflectionUnionType) {
             $types = $type->getTypes();
-            if (\PHP_VERSION_ID >= 80200) {
-                foreach ($types as $reflectionType) {
-                    if ($reflectionType instanceof ReflectionIntersectionType) {
-                        throw new ClassMirrorException('Doubling intersection types is not supported', $class);
-                    }
+            foreach ($types as $reflectionType) {
+                if ($reflectionType instanceof ReflectionIntersectionType) {
+                    throw new ClassMirrorException('Doubling intersection types is not supported', $class);
                 }
             }
         } elseif ($type instanceof ReflectionIntersectionType) {

--- a/src/Prophecy/Doubler/Generator/Node/TypeNodeAbstract.php
+++ b/src/Prophecy/Doubler/Generator/Node/TypeNodeAbstract.php
@@ -74,9 +74,8 @@ abstract class TypeNodeAbstract
             case 'iterable':
             case 'object':
             case 'null':
-                return $type;
             case 'mixed':
-                return \PHP_VERSION_ID < 80000 ? $this->prefixWithNsSeparator($type) : $type;
+                return $type;
 
             default:
                 return $this->prefixWithNsSeparator($type);
@@ -88,29 +87,7 @@ abstract class TypeNodeAbstract
      */
     protected function guardIsValidType()
     {
-        if (\PHP_VERSION_ID < 80200) {
-            if ($this->types == ['null' => 'null']) {
-                throw new DoubleException('Type cannot be standalone null');
-            }
-
-            if ($this->types == ['false' => 'false']) {
-                throw new DoubleException('Type cannot be standalone false');
-            }
-
-            if ($this->types == ['false' => 'false', 'null' => 'null']) {
-                throw new DoubleException('Type cannot be nullable false');
-            }
-
-            if ($this->types == ['true' => 'true']) {
-                throw new DoubleException('Type cannot be standalone true');
-            }
-
-            if ($this->types == ['true' => 'true', 'null' => 'null']) {
-                throw new DoubleException('Type cannot be nullable true');
-            }
-        }
-
-        if (\PHP_VERSION_ID >= 80000 && isset($this->types['mixed']) && count($this->types) !== 1) {
+        if (isset($this->types['mixed']) && count($this->types) !== 1) {
             throw new DoubleException('mixed cannot be part of a union');
         }
     }

--- a/src/Prophecy/Doubler/Generator/TypeHintReference.php
+++ b/src/Prophecy/Doubler/Generator/TypeHintReference.php
@@ -27,10 +27,8 @@ final class TypeHintReference
             case 'string':
             case 'iterable':
             case 'object':
-                return true;
-
             case 'mixed':
-                return PHP_VERSION_ID >= 80000;
+                return true;
 
             default:
                 return false;

--- a/tests/Argument/Token/ExactValueTokenTest.php
+++ b/tests/Argument/Token/ExactValueTokenTest.php
@@ -9,12 +9,11 @@ use Prophecy\Argument\Token\ExactValueToken;
 class ExactValueTokenTest extends TestCase
 {
     /**
-     * @test
      * @see https://github.com/phpspec/prophecy/issues/268
      * @see https://stackoverflow.com/a/19097159/2424814
      */
     #[Test]
-    public function does_not_trigger_nesting_error()
+    public function does_not_trigger_nesting_error(): void
     {
         $child1 = new ChildClass('A', new ParentClass());
         $child2 = new ChildClass('B', new ParentClass());
@@ -23,11 +22,8 @@ class ExactValueTokenTest extends TestCase
         self::assertEquals(false, $exactValueToken->scoreArgument($child2));
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function scores_10_for_objects_with_same_fields()
+    public function scores_10_for_objects_with_same_fields(): void
     {
         $child1 = new ChildClass('A', new ParentClass());
         $child2 = new ChildClass('A', new ParentClass());
@@ -36,11 +32,8 @@ class ExactValueTokenTest extends TestCase
         self::assertEquals(10, $exactValueToken->scoreArgument($child2));
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function scores_10_for_matching_callables()
+    public function scores_10_for_matching_callables(): void
     {
         $callable = function () {};
 
@@ -48,11 +41,8 @@ class ExactValueTokenTest extends TestCase
         self::assertEquals(10, $exactValueToken->scoreArgument($callable));
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function scores_false_for_object_and_string()
+    public function scores_false_for_object_and_string(): void
     {
         $child1 = new ChildClass('A', new ParentClass());
 
@@ -60,11 +50,8 @@ class ExactValueTokenTest extends TestCase
         self::assertEquals(false, $exactValueToken->scoreArgument("A"));
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function scores_false_for_object_and_int()
+    public function scores_false_for_object_and_int(): void
     {
         $child1 = new ChildClass('A', new ParentClass());
 
@@ -72,11 +59,8 @@ class ExactValueTokenTest extends TestCase
         self::assertEquals(false, $exactValueToken->scoreArgument(100));
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function scores_false_for_object_and_stdclass()
+    public function scores_false_for_object_and_stdclass(): void
     {
         $child1 = new ChildClass('A', new ParentClass());
 
@@ -84,11 +68,8 @@ class ExactValueTokenTest extends TestCase
         self::assertEquals(false, $exactValueToken->scoreArgument(new \stdClass()));
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function scores_false_for_object_and_null()
+    public function scores_false_for_object_and_null(): void
     {
         $child1 = new ChildClass('A', new ParentClass());
 

--- a/tests/Comparator/FactoryProviderTest.php
+++ b/tests/Comparator/FactoryProviderTest.php
@@ -9,11 +9,8 @@ use PHPUnit\Framework\TestCase;
 
 class FactoryProviderTest extends TestCase
 {
-    /**
-     * @test
-     */
     #[Test]
-    function it_should_have_ClosureComparator_registered()
+    function it_should_have_ClosureComparator_registered(): void
     {
         $comparator = FactoryProvider::getInstance()->getComparatorFor(function () {}, function () {});
 

--- a/tests/Doubler/ClassPatch/MagicCallPatchTest.php
+++ b/tests/Doubler/ClassPatch/MagicCallPatchTest.php
@@ -11,11 +11,8 @@ use Prophecy\Doubler\Generator\Node\ClassNode;
 
 class MagicCallPatchTest extends TestCase
 {
-    /**
-     * @test
-     */
     #[Test]
-    public function it_supports_classes_with_invalid_tags()
+    public function it_supports_classes_with_invalid_tags(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\WithPhpdocClass');
 
@@ -31,11 +28,8 @@ class MagicCallPatchTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_supports_arguments_for_magic_methods()
+    public function it_supports_arguments_for_magic_methods(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\WithPhpdocClass');
 

--- a/tests/Doubler/Generator/ClassMirrorTest.php
+++ b/tests/Doubler/Generator/ClassMirrorTest.php
@@ -14,11 +14,8 @@ use Prophecy\Prophet;
 
 class ClassMirrorTest extends TestCase
 {
-    /**
-     * @test
-     */
     #[Test]
-    public function it_reflects_allowed_magic_methods()
+    public function it_reflects_allowed_magic_methods(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\SpecialMethods');
 
@@ -29,11 +26,8 @@ class ClassMirrorTest extends TestCase
         $this->assertCount(7, $node->getMethods());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_reflects_protected_abstract_methods()
+    public function it_reflects_protected_abstract_methods(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\WithProtectedAbstractMethod');
 
@@ -49,11 +43,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals('protected', $methodNodes['innerDetail']->getVisibility());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_reflects_public_static_methods()
+    public function it_reflects_public_static_methods(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\WithStaticMethod');
 
@@ -69,11 +60,8 @@ class ClassMirrorTest extends TestCase
         $this->assertTrue($methodNodes['innerDetail']->isStatic());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_marks_required_args_without_types_as_not_optional()
+    public function it_marks_required_args_without_types_as_not_optional(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\WithArguments');
 
@@ -93,11 +81,8 @@ class ClassMirrorTest extends TestCase
         $this->assertFalse($argNodes[0]->isVariadic());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_properly_reads_methods_arguments_with_types()
+    public function it_properly_reads_methods_arguments_with_types(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\WithArguments');
 
@@ -129,11 +114,8 @@ class ClassMirrorTest extends TestCase
         $this->assertFalse($argNodes[2]->isVariadic());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_properly_reads_methods_arguments_with_callable_types()
+    public function it_properly_reads_methods_arguments_with_callable_types(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\WithCallableArgument');
 
@@ -159,11 +141,8 @@ class ClassMirrorTest extends TestCase
         $this->assertFalse($argNodes[1]->isVariadic());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_properly_reads_methods_variadic_arguments()
+    public function it_properly_reads_methods_variadic_arguments(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\WithVariadicArgument');
 
@@ -182,11 +161,8 @@ class ClassMirrorTest extends TestCase
         $this->assertTrue($argNodes[0]->isVariadic());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_properly_reads_methods_typehinted_variadic_arguments()
+    public function it_properly_reads_methods_typehinted_variadic_arguments(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\WithTypehintedVariadicArgument');
 
@@ -205,11 +181,8 @@ class ClassMirrorTest extends TestCase
         $this->assertTrue($argNodes[0]->isVariadic());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_marks_passed_by_reference_args_as_passed_by_reference()
+    public function it_marks_passed_by_reference_args_as_passed_by_reference(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\WithReferences');
 
@@ -227,11 +200,8 @@ class ClassMirrorTest extends TestCase
         $this->assertTrue($argNodes[1]->isPassedByReference());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_throws_an_exception_if_class_is_final()
+    public function it_throws_an_exception_if_class_is_final(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\FinalClass');
 
@@ -242,11 +212,8 @@ class ClassMirrorTest extends TestCase
         $mirror->reflect($class, array());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_ignores_final_methods()
+    public function it_ignores_final_methods(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\WithFinalMethod');
 
@@ -257,11 +224,8 @@ class ClassMirrorTest extends TestCase
         $this->assertCount(0, $classNode->getMethods());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_marks_final_methods_as_unextendable()
+    public function it_marks_final_methods_as_unextendable(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\WithFinalMethod');
 
@@ -273,11 +237,8 @@ class ClassMirrorTest extends TestCase
         $this->assertFalse($classNode->isExtendable('finalImplementation'));
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_throws_an_exception_if_interface_provided_instead_of_class()
+    public function it_throws_an_exception_if_interface_provided_instead_of_class(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\EmptyInterface');
 
@@ -288,11 +249,8 @@ class ClassMirrorTest extends TestCase
         $mirror->reflect($class, array());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_reflects_all_interfaces_methods()
+    public function it_reflects_all_interfaces_methods(): void
     {
         $mirror = new ClassMirror();
 
@@ -314,11 +272,8 @@ class ClassMirrorTest extends TestCase
         $this->assertTrue($classNode->hasMethod('getVisibility'));
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_ignores_virtually_private_methods()
+    public function it_ignores_virtually_private_methods(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\WithVirtuallyPrivateMethod');
 
@@ -332,11 +287,8 @@ class ClassMirrorTest extends TestCase
         $this->assertFalse($classNode->hasMethod('_getName'));
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_does_not_throw_exception_for_virtually_private_finals()
+    public function it_does_not_throw_exception_for_virtually_private_finals(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\WithFinalVirtuallyPrivateMethod');
 
@@ -347,11 +299,8 @@ class ClassMirrorTest extends TestCase
         $this->assertCount(0, $classNode->getMethods());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_reflects_return_typehints()
+    public function it_reflects_return_typehints(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\WithReturnTypehints');
 
@@ -369,11 +318,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ReturnTypeNode('\Fixtures\Prophecy\EmptyClass'), $classNode->getMethod('getParent')->getReturnTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_throws_an_exception_if_class_provided_in_interfaces_list()
+    public function it_throws_an_exception_if_class_provided_in_interfaces_list(): void
     {
         $class = new \ReflectionClass('Fixtures\Prophecy\EmptyClass');
 
@@ -384,11 +330,8 @@ class ClassMirrorTest extends TestCase
         $mirror->reflect(null, array($class));
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_throws_an_exception_if_not_reflection_provided_as_interface()
+    public function it_throws_an_exception_if_not_reflection_provided_as_interface(): void
     {
         $mirror = new ClassMirror();
 
@@ -397,32 +340,8 @@ class ClassMirrorTest extends TestCase
         $mirror->reflect(null, array(null));
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_doesnt_use_scalar_typehints()
-    {
-        if (PHP_VERSION_ID >= 80000) {
-            $this->markTestSkipped('Internal types have scalar hints in PHP 8');
-        }
-
-        $mirror = new ClassMirror();
-
-        $classNode = $mirror->reflect(new \ReflectionClass('ReflectionMethod'), array());
-        $method = $classNode->getMethod('export');
-        $arguments = $method->getArguments();
-
-        $this->assertEquals(new ArgumentTypeNode(), $arguments[0]->getTypeNode());
-        $this->assertEquals(new ArgumentTypeNode(), $arguments[1]->getTypeNode());
-        $this->assertEquals(new ArgumentTypeNode(), $arguments[2]->getTypeNode());
-    }
-
-    /**
-     * @test
-     */
-    #[Test]
-    public function it_doesnt_fail_to_typehint_nonexistent_FQCN()
+    public function it_doesnt_fail_to_typehint_nonexistent_FQCN(): void
     {
         $mirror = new ClassMirror();
 
@@ -432,11 +351,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ArgumentTypeNode('I\Simply\Am\Nonexistent'), $arguments[0]->getTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_doesnt_fail_on_array_nullable_parameter_with_not_null_default_value()
+    public function it_doesnt_fail_on_array_nullable_parameter_with_not_null_default_value(): void
     {
         $mirror = new ClassMirror();
 
@@ -446,11 +362,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ArgumentTypeNode('array', 'null'), $arguments[0]->getTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_doesnt_fail_to_typehint_nonexistent_RQCN()
+    public function it_doesnt_fail_to_typehint_nonexistent_RQCN(): void
     {
         $mirror = new ClassMirror();
 
@@ -460,11 +373,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ArgumentTypeNode('I\Simply\Am\Not'), $arguments[0]->getTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    function it_doesnt_fail_when_method_is_extended_with_more_params()
+    function it_doesnt_fail_when_method_is_extended_with_more_params(): void
     {
         $mirror = new ClassMirror();
 
@@ -479,11 +389,8 @@ class ClassMirrorTest extends TestCase
         $this->assertCount(2, $method->getArguments());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    function it_doesnt_fail_to_mock_self_referencing_interface()
+    function it_doesnt_fail_to_mock_self_referencing_interface(): void
     {
         $mirror = new ClassMirror();
 
@@ -497,11 +404,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ReturnTypeNode(SelfReferencing::class), $method->getReturnTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    function it_changes_argument_names_if_they_are_varying()
+    function it_changes_argument_names_if_they_are_varying(): void
     {
         // Use test doubles in this test, as arguments named ... in the Reflection API can only happen for internal classes
         $prophet = new Prophet();
@@ -553,11 +457,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals('__dot_dot_dot__', $argumentNode->getName());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_double_a_class_with_union_return_types()
+    public function it_can_double_a_class_with_union_return_types(): void
     {
         if (PHP_VERSION_ID < 80000) {
             $this->markTestSkipped('Union types are not supported in this PHP version');
@@ -569,11 +470,8 @@ class ClassMirrorTest extends TestCase
         $this->assertSame(['\stdClass', 'bool'], $methodNode->getReturnTypeNode()->getTypes());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_double_a_class_with_union_return_type_with_false()
+    public function it_can_double_a_class_with_union_return_type_with_false(): void
     {
         if (PHP_VERSION_ID < 80000) {
             $this->markTestSkipped('Union types with false are not supported in this PHP version');
@@ -585,9 +483,8 @@ class ClassMirrorTest extends TestCase
         $this->assertSame(['\stdClass', 'false'], $methodNode->getReturnTypeNode()->getTypes());
     }
 
-    /** @test */
     #[Test]
-    public function it_can_double_a_class_with_union_argument_types()
+    public function it_can_double_a_class_with_union_argument_types(): void
     {
         if (PHP_VERSION_ID < 80000) {
             $this->markTestSkipped('Union types are not supported in this PHP version');
@@ -599,11 +496,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ArgumentTypeNode('bool', '\\stdClass'), $methodNode->getArguments()[0]->getTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_double_a_class_with_union_argument_type_with_false()
+    public function it_can_double_a_class_with_union_argument_type_with_false(): void
     {
         if (PHP_VERSION_ID < 80000) {
             $this->markTestSkipped('Union types with false are not supported in this PHP version');
@@ -615,9 +509,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ArgumentTypeNode('false', '\stdClass'), $methodNode->getArguments()[0]->getTypeNode());
     }
 
-    /** @test */
     #[Test]
-    public function it_can_double_a_class_with_mixed_types()
+    public function it_can_double_a_class_with_mixed_types(): void
     {
         if (PHP_VERSION_ID < 80000) {
             $this->markTestSkipped('Mixed type is not supported in this PHP version');
@@ -630,9 +523,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ReturnTypeNode('mixed'), $methodNode->getReturnTypeNode());
     }
 
-    /** @test */
     #[Test]
-    public function it_can_double_inherited_self_return_type()
+    public function it_can_double_inherited_self_return_type(): void
     {
         $classNode = (new ClassMirror())->reflect(new \ReflectionClass('Fixtures\Prophecy\ClassExtendAbstractWithMethodWithReturnType'), []);
         $methodNode = $classNode->getMethods()['returnSelf'];
@@ -640,11 +532,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ReturnTypeNode('Fixtures\Prophecy\AbstractBaseClassWithMethodWithReturnType'), $methodNode->getReturnTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_double_never_return_type()
+    public function it_can_double_never_return_type(): void
     {
         if (PHP_VERSION_ID < 80100) {
             $this->markTestSkipped('Never type is not supported in this PHP version');
@@ -657,11 +546,8 @@ class ClassMirrorTest extends TestCase
 
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_not_double_an_enum()
+    public function it_can_not_double_an_enum(): void
     {
         if (PHP_VERSION_ID < 80100) {
             $this->markTestSkipped('Enums are not supported in this PHP version');
@@ -672,11 +558,8 @@ class ClassMirrorTest extends TestCase
         $classNode = (new ClassMirror())->reflect(new \ReflectionClass('Fixtures\Prophecy\Enum'), []);
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_not_double_intersection_return_types()
+    public function it_can_not_double_intersection_return_types(): void
     {
         if (PHP_VERSION_ID < 80100) {
             $this->markTestSkipped('Intersection types are not supported in this PHP version');
@@ -687,11 +570,8 @@ class ClassMirrorTest extends TestCase
         $classNode = (new ClassMirror())->reflect(new \ReflectionClass('Fixtures\Prophecy\IntersectionReturnType'), []);
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_not_double_intersection_argument_types()
+    public function it_can_not_double_intersection_argument_types(): void
     {
         if (PHP_VERSION_ID < 80100) {
             $this->markTestSkipped('Intersection types are not supported in this PHP version');
@@ -702,11 +582,8 @@ class ClassMirrorTest extends TestCase
         $classNode = (new ClassMirror())->reflect(new \ReflectionClass('Fixtures\Prophecy\IntersectionArgumentType'), []);
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_double_a_standalone_return_type_of_false()
+    public function it_can_double_a_standalone_return_type_of_false(): void
     {
         if (PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('Standalone return type of false is not supported in this PHP version');
@@ -718,11 +595,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ReturnTypeNode('false'), $methodNode->getReturnTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_double_a_standalone_parameter_type_of_false()
+    public function it_can_double_a_standalone_parameter_type_of_false(): void
     {
         if (PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('Standalone parameter type of false is not supported in this PHP version');
@@ -735,11 +609,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ArgumentTypeNode('false'), $arguments[0]->getTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_double_a_nullable_return_type_of_false()
+    public function it_can_double_a_nullable_return_type_of_false(): void
     {
         if (PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('Nullable return type of false is not supported in this PHP version');
@@ -751,11 +622,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ReturnTypeNode('null', 'false'), $methodNode->getReturnTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_double_a_nullable_parameter_type_of_false()
+    public function it_can_double_a_nullable_parameter_type_of_false(): void
     {
         if (PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('Nullable parameter type of false is not supported in this PHP version');
@@ -768,11 +636,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ArgumentTypeNode('null', 'false'), $arguments[0]->getTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_not_double_dnf_intersection_argument_types()
+    public function it_can_not_double_dnf_intersection_argument_types(): void
     {
         if (PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('DNF intersection types are not supported in this PHP version');
@@ -783,11 +648,8 @@ class ClassMirrorTest extends TestCase
         $classNode = (new ClassMirror())->reflect(new \ReflectionClass('Fixtures\Prophecy\DnfArgumentType'), []);
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_not_double_dnf_intersection_return_types()
+    public function it_can_not_double_dnf_intersection_return_types(): void
     {
         if (PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('DNF intersection types are not supported in this PHP version');
@@ -798,11 +660,8 @@ class ClassMirrorTest extends TestCase
         $classNode = (new ClassMirror())->reflect(new \ReflectionClass('Fixtures\Prophecy\DnfReturnType'), []);
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_double_a_standalone_return_type_of_true()
+    public function it_can_double_a_standalone_return_type_of_true(): void
     {
         if (PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('Standalone return type of true is not supported in this PHP version');
@@ -814,11 +673,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ReturnTypeNode('true'), $methodNode->getReturnTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_reflects_non_read_only_class()
+    public function it_reflects_non_read_only_class(): void
     {
         $classNode = (new ClassMirror())->reflect(
             new \ReflectionClass('Fixtures\Prophecy\EmptyClass'),
@@ -828,11 +684,8 @@ class ClassMirrorTest extends TestCase
         $this->assertFalse($classNode->isReadOnly());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_double_a_standalone_parameter_type_of_true()
+    public function it_can_double_a_standalone_parameter_type_of_true(): void
     {
         if (PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('Standalone parameter type of true is not supported in this PHP version');
@@ -845,11 +698,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ArgumentTypeNode('true'), $arguments[0]->getTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_double_a_nullable_return_type_of_true()
+    public function it_can_double_a_nullable_return_type_of_true(): void
     {
         if (PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('Nullable return type of true is not supported in this PHP version');
@@ -861,11 +711,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ReturnTypeNode('null', 'true'), $methodNode->getReturnTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_double_a_nullable_parameter_type_of_true()
+    public function it_can_double_a_nullable_parameter_type_of_true(): void
     {
         if (PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('Nullable parameter type of true is not supported in this PHP version');
@@ -878,11 +725,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ArgumentTypeNode('null', 'true'), $arguments[0]->getTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_double_a_standalone_return_type_of_null()
+    public function it_can_double_a_standalone_return_type_of_null(): void
     {
         if (PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('Standalone return type of null is not supported in this PHP version');
@@ -894,11 +738,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ReturnTypeNode('null'), $methodNode->getReturnTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_can_double_a_standalone_parameter_type_of_null()
+    public function it_can_double_a_standalone_parameter_type_of_null(): void
     {
         if (PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('Standalone parameter type of null is not supported in this PHP version');
@@ -911,11 +752,8 @@ class ClassMirrorTest extends TestCase
         $this->assertEquals(new ArgumentTypeNode('null'), $arguments[0]->getTypeNode());
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_reflects_read_only_class()
+    public function it_reflects_read_only_class(): void
     {
         if (PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('Read only classes are not supported in this PHP version');

--- a/tests/Doubler/Generator/Node/TypeNodeAbstractTest.php
+++ b/tests/Doubler/Generator/Node/TypeNodeAbstractTest.php
@@ -34,10 +34,6 @@ class TypeNodeAbstractTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     * @dataProvider childClassDataProvider
-     */
     #[DataProvider('childClassDataProvider')]
     #[Test]
     public function it_can_use_null_shorthand_only_with_two_types(TypeNodeAbstract $node, bool $expected): void

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -12,11 +12,8 @@ use Prophecy\Prophet;
 
 class FunctionalTest extends TestCase
 {
-    /**
-     * @test
-     */
     #[Test]
-    public function case_insensitive_method_names()
+    public function case_insensitive_method_names(): void
     {
         $prophet = new Prophet();
         $prophecy = $prophet->prophesize('ArrayObject');
@@ -30,11 +27,8 @@ class FunctionalTest extends TestCase
         self::assertSame(3, $arrayObject->offsetGet(3));
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_implements_the_double_interface()
+    public function it_implements_the_double_interface(): void
     {
         $prophet = new Prophet();
         $object = $prophet->prophesize('stdClass')->reveal();
@@ -42,11 +36,8 @@ class FunctionalTest extends TestCase
         $this->assertInstanceOf(DoubleInterface::class, $object);
     }
 
-    /**
-     * @test
-     */
     #[Test]
-    public function it_implements_the_prophecy_subject_interface()
+    public function it_implements_the_prophecy_subject_interface(): void
     {
         $prophet = new Prophet();
         $object = $prophet->prophesize('stdClass')->reveal();
@@ -54,7 +45,7 @@ class FunctionalTest extends TestCase
         $this->assertInstanceOf(ProphecySubjectInterface::class, $object);
     }
 
-    public function testUnconfiguredFinalReturnType()
+    public function testUnconfiguredFinalReturnType(): void
     {
         $prophet = new Prophet();
         $object = $prophet->prophesize(ReturningFinalClass::class);


### PR DESCRIPTION
I started to work on #637 but supporting old versions of PHP is a lot of work and adds a layer we do not really need anymore since those versions are not supported anymore by PHP itself.

This is why I'm proposing here a PR that bump the minimum version of PHP.

https://www.php.net/supported-versions

Side note: _8.1 is also removed because a lot changed between 8.1 and 8.2 about types and the end of its support also comes soon enough._

Closes #431