### PR TITLE
Allow PHPSpec 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.2", "8.3"]
+        php: ["8.2", "8.3", "8.4"]
         composer-flags: [ "" ]
         experimental: [ false ]
         include:
           - php: 8.2
             composer-flags: "--prefer-lowest"
-          - php: "8.4" # TODO move that to a normal job once phpspec supports PHP 8.4
+          - php: "8.5" # TODO move that to a normal job once phpspec supports PHP 8.5
             composer-flags: "--ignore-platform-req=php+"
           - php: nightly
             composer-flags: "--ignore-platform-req=php+"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.40",
-        "phpspec/phpspec": "^6.0 || ^7.0",
+        "phpspec/phpspec": "^6.0 || ^7.0 || ^8.0",
         "phpstan/phpstan": "^2.1.13",
         "phpunit/phpunit": "^11.0 || ^12.0"
     },


### PR DESCRIPTION
This should unlock PHP (edit: clean) 8.4 in CI. I'm taking the occasion to test against PHP 8.5 too.