### PR TITLE
Fix the php-cs-fixer config for the new version

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -14,7 +14,7 @@ return (new PhpCsFixer\Config())
         'method_argument_space' => ['on_multiline' => 'ignore'],
         // Since PHP 7.2 is supported we can't add trailing commas in arguments, parameters and match
         'trailing_comma_in_multiline' => ['elements' => ['arrays']],
-        'visibility_required' => false,
+        'modifier_keywords' => false,
     ])
     ->setFinder(
         (new PhpCsFixer\Finder())

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
 
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.40",
+        "friendsofphp/php-cs-fixer": "^3.88",
         "phpspec/phpspec": "^6.0 || ^7.0 || ^8.0",
         "phpstan/phpstan": "^2.1.13",
         "phpunit/phpunit": "^11.0 || ^12.0"


### PR DESCRIPTION
PHP-CS-Fixer has renamed the `visibility_required` fixer in 3.88. They have a BC layer in place, but it does not seem to work to disable a fixer entirely (which I reported at https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/9113).
This updates the config to use the new name so that disabling the fixer works.