### PR TITLE
Add support for `phpdocumentor/reflection-docblock` v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 
     "require": {
         "php":                               "8.2.* || 8.3.* || 8.4.* || 8.5.*",
-        "phpdocumentor/reflection-docblock": "^5.2",
+        "phpdocumentor/reflection-docblock": "^5.2 || ^6.0",
         "sebastian/comparator":              "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
         "doctrine/instantiator":             "^1.2 || ^2.0",
         "sebastian/recursion-context":       "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -65,3 +65,9 @@ parameters:
 			identifier: offsetAccess.invalidOffset
 			count: 1
 			path: src/Prophecy/Util/ExportUtil.php
+
+		-
+			message: '#^Call to an undefined method phpDocumentor\\Reflection\\DocBlock\\Tags\\Method\:\:getArguments\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Prophecy/Doubler/ClassPatch/MagicCallPatch.php


### PR DESCRIPTION
The package https://github.com/phpDocumentor/Reflection needs to be upgraded to `phpdocumentor/reflection-docblock` v6, but this is currently not possible because `phpspec/prophecy` requires version `^5.2`.

<img width="1445" height="217" alt="image" src="https://github.com/user-attachments/assets/2d7594aa-3708-4705-8ada-4e272c91eee8" />

Closes #661 
