### PR TITLE
Allow PHPUnit 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     "require": {
         "php":                               "8.2.* || 8.3.* || 8.4.* || 8.5.*",
         "phpdocumentor/reflection-docblock": "^5.2",
-        "sebastian/comparator":              "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "sebastian/comparator":              "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
         "doctrine/instantiator":             "^1.2 || ^2.0",
-        "sebastian/recursion-context":       "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "sebastian/recursion-context":       "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
         "symfony/deprecation-contracts":     "^2.5 || ^3.1"
     },
 
@@ -30,7 +30,7 @@
         "friendsofphp/php-cs-fixer": "^3.88",
         "phpspec/phpspec": "^6.0 || ^7.0 || ^8.0",
         "phpstan/phpstan": "^2.1.13",
-        "phpunit/phpunit": "^11.0 || ^12.0"
+        "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.88",
         "phpspec/phpspec": "^6.0 || ^7.0 || ^8.0",
-        "phpstan/phpstan": "^2.1.13",
+        "phpstan/phpstan": "^2.1.13, <=2.1.33",
         "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0"
     },
 


### PR DESCRIPTION
Draft because this is blocked by PHPSpec allowing the same.