### PR TITLE
Prevent installing phpstan 2.1.34

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.88",
         "phpspec/phpspec": "^6.0 || ^7.0 || ^8.0",
-        "phpstan/phpstan": "^2.1.13",
+        "phpstan/phpstan": "^2.1.13, !=2.1.34",
         "phpunit/phpunit": "^11.0 || ^12.0"
     },
 


### PR DESCRIPTION
phpstan 2.1.34 has a bug impacting the analysis of generic classes, including SplObjectStorage.

https://github.com/phpstan/phpstan/issues/13985