### PR TITLE
Fix the phpstan range to forbid broken versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.88",
         "phpspec/phpspec": "^6.0 || ^7.0 || ^8.0",
-        "phpstan/phpstan": "^2.1.13, !=2.1.34",
+        "phpstan/phpstan": "^2.1.13, <2.1.34 || ^2.1.39",
         "phpunit/phpunit": "^11.0 || ^12.0"
     },
 


### PR DESCRIPTION
Follow-up of #665 as 2.1.34 (introducing the bug) is not actually the latest release.